### PR TITLE
Fixes credit card buy

### DIFF
--- a/assets/javascripts/front/app/component-checkout-transparent.js
+++ b/assets/javascripts/front/app/component-checkout-transparent.js
@@ -50,12 +50,6 @@ MONSTER( 'Pagarme.Components.CheckoutTransparent', function(Model, $, utils) {
 			return false;
 		}
 
-		$( 'body' ).trigger( 'onPagarmeSubmit', [ e ] )
-
-		if ( $('input[name=payment_method]').val() === 'billet' ) {
-			this.loadSwal();
-		}
-
 		$( 'body' ).on( 'onPagarmeCheckoutDone', function(){
 			if ( $( 'input[name=payment_method]' ).val() == '2_cards' ) {
 				return;
@@ -69,6 +63,12 @@ MONSTER( 'Pagarme.Components.CheckoutTransparent', function(Model, $, utils) {
 			}
 			window.Pagarme2Cards = 0;
 		}.bind(this));
+
+		$( 'body' ).trigger( 'onPagarmeSubmit', [ e ] )
+
+		if ( $('input[name=payment_method]').val() === 'billet' ) {
+			this.loadSwal();
+		}
 	};
 
 	Model.fn._onClickTab = function(event) {

--- a/assets/javascripts/front/built.js
+++ b/assets/javascripts/front/built.js
@@ -2609,14 +2609,6 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			return false;
 		}
 
-		jQuery('#wcmp-submit').attr('disabled', 'disabled');
-
-		$( 'body' ).trigger( 'onPagarmeSubmit', [ e ] )
-
-		if ( $('input[name=payment_method]').val() === 'billet' ) {
-			this.loadSwal();
-		}
-
 		$( 'body' ).on( 'onPagarmeCheckoutDone', function(){
 			if ( $( 'input[name=payment_method]' ).val() == '2_cards' ) {
 				return;
@@ -2630,6 +2622,16 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 			window.Pagarme2Cards = 0;
 		}.bind(this));
+
+		jQuery('#wcmp-submit').attr('disabled', 'disabled');
+
+		$( 'body' ).trigger( 'onPagarmeSubmit', [ e ] )
+
+		if ( $('input[name=payment_method]').val() === 'billet' ) {
+			this.loadSwal();
+		}
+
+
 	};
 
 	Model.fn._onClickTab = function(event) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         |   https://mundipagg.atlassian.net/browse/PAA-218
| **What?**         | Fixes order creation in a buy done with a saved credit card.
| **Why?**          | Woocommerce module just stucks when trying to create a order with a saved credit card.
| **How?**          | Creating a order with a saved credit card triggers a javascript event ("onPagarmeCheckoutDone") before the respective callback was defined.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)
Using sandbox keys in module, if we save the card 4000000000000010 and try to generate an order with the saved card, the button just disables and the screen didn't respond, like the image below:

![image-20210209-210557](https://user-images.githubusercontent.com/12115674/107687831-bbac1800-6c85-11eb-88ad-a7c854448ccd.png)

#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!