### PR TITLE
Fix checkout/order-pay tabs incompatibility

### DIFF
--- a/templates/checkout/main.php
+++ b/templates/checkout/main.php
@@ -39,6 +39,9 @@ $swal_data   = array(
 		<div class="woocommerce-tabs">
 			<ul class="tabs">
 
+			<li class="wcmp-tab-woocommerce-compatibility" style="display: none;">
+			</li>
+
 			<?php
 			if ( $this->model->settings->is_active_credit_card() ) :
 				$tab_credit_card = true;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         |   https://mundipagg.atlassian.net/browse/PAA-244
| **What?**         | Fix checkout/order-pay tabs incompatibility. We use the single-product woocommerce tabs style, and some plugins have some behaviour for the single product page that ends up occurring to our tabs, such as "always clicking at the first tab" (which is the problem this pull request is solving).
| **How?**          | Adding an empty html `<li>` tag as the first tab, so the click does nothing. NOTES: Alternatively we could style or tabs using an own style, but it would take a lot more time and we probably would have theme compatibility issues, being necessary adding tab color settings to our plugin. Other alternative could be find another wordpress/woocommerce frontend common tab style to use, but unfortunately we didn't get to find one.

**Relates to: https://github.com/mundipagg/woocommerce/pull/19**

#### :package: Attachments (if appropriate)
Woocommerce file which has the "click at the first tab" behaviour:
https://github.com/woocommerce/woocommerce/blob/master/assets/js/frontend/single-product.js#L25

Plugin which adds the single-product.js file to woocommerce order-pay page:
https://essential-addons.com/elementor/