### PR TITLE
Fix boleto bank requirement

### DIFF
--- a/assets/javascripts/admin/app/component-settings.js
+++ b/assets/javascripts/admin/app/component-settings.js
@@ -21,6 +21,7 @@ MONSTER( 'Pagarme.Components.Settings', function(Model, $, Utils) {
 
 		this.handleEnvironmentFieldsVisibility( this.elements.environmentSelect.val() );
 		this.handleInstallmentFieldsVisibility( this.elements.installmentsTypeSelect.val() );
+		this.handleBilletBankRequirement();
 
 		this.setInstallmentsByFlags( null, true );
 
@@ -31,6 +32,8 @@ MONSTER( 'Pagarme.Components.Settings', function(Model, $, Utils) {
 		this.on( 'keyup', 'soft-descriptor' );
 		this.on( 'change', 'environment' );
 		this.on( 'change', 'installments-type' );
+		this.on( 'change', 'enable-billet' );
+    	this.on( 'change', 'enable-multimethods-billet-card' );
 
 		this.elements.flagsSelect.on( 'select2:unselecting', this._onChangeFlags.bind(this) );
 		this.elements.flagsSelect.on( 'select2:selecting', this._onChangeFlags.bind(this) );
@@ -62,6 +65,14 @@ MONSTER( 'Pagarme.Components.Settings', function(Model, $, Utils) {
 
 	Model.fn._onChangeInstallmentsType = function( event ) {
 		this.handleInstallmentFieldsVisibility( event.currentTarget.value );
+	};
+
+	Model.fn._onChangeEnableBillet = function() {
+		this.handleBilletBankRequirement();
+	};
+
+	Model.fn._onChangeEnableMultimethodsBilletCard = function() {
+		this.handleBilletBankRequirement();
 	};
 
 	Model.fn._onChangeFlags = function( event ) {
@@ -140,6 +151,26 @@ MONSTER( 'Pagarme.Components.Settings', function(Model, $, Utils) {
 			installmentsWithoutInterestContainer.hide();
 		}
 	};
+
+	Model.fn.handleBilletBankRequirement = function() {    
+		let bankRequirementFields = $( '[data-requires-field="billet-bank"]' );    
+		let billet_bank_element_id = '#woocommerce_woo-pagarme-payments_billet_bank';
+		let billetBankIsRequired = false;
+
+		bankRequirementFields.each(function() {
+			if ( $( this ).prop( "checked" ) ) {
+				billetBankIsRequired = true;
+				return false;
+			}
+		});
+
+		if ( billetBankIsRequired ) {
+			$( billetBankElementId ).attr( 'required', true );
+			return;
+		}
+
+		$( billetBankElementId ).attr( 'required', false );
+	}; 	
 
 	Model.fn.setInstallmentsByFlags = function( event, firstLoad ) {
 		var flags        = this.elements.flagsSelect.val() || [];

--- a/assets/javascripts/admin/built.js
+++ b/assets/javascripts/admin/built.js
@@ -4107,6 +4107,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 
 		this.handleEnvironmentFieldsVisibility( this.elements.environmentSelect.val() );
 		this.handleInstallmentFieldsVisibility( this.elements.installmentsTypeSelect.val() );
+		this.handleBilletBankRequirement();
 
 		this.setInstallmentsByFlags( null, true );
 
@@ -4117,6 +4118,8 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		this.on( 'keyup', 'soft-descriptor' );
 		this.on( 'change', 'environment' );
 		this.on( 'change', 'installments-type' );
+		this.on( 'change', 'enable-billet' );
+		this.on( 'change', 'enable-multimethods-billet-card' );
 
 		this.elements.flagsSelect.on( 'select2:unselecting', this._onChangeFlags.bind(this) );
 		this.elements.flagsSelect.on( 'select2:selecting', this._onChangeFlags.bind(this) );
@@ -4148,6 +4151,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 
 	Model.fn._onChangeInstallmentsType = function( event ) {
 		this.handleInstallmentFieldsVisibility( event.currentTarget.value );
+	};
+
+	Model.fn._onChangeEnableBillet = function() {
+		this.handleBilletBankRequirement();
+	};
+
+	Model.fn._onChangeEnableMultimethodsBilletCard = function() {
+		this.handleBilletBankRequirement();
 	};
 
 	Model.fn._onChangeFlags = function( event ) {
@@ -4226,6 +4237,26 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			installmentsWithoutInterestContainer.hide();
 		}
 	};
+
+	Model.fn.handleBilletBankRequirement = function() {
+		let bankRequirementFields = $( '[data-requires-field="billet-bank"]' );
+		let billetBankElementId = '#woocommerce_woo-pagarme-payments_billet_bank';
+		let billetBankIsRequired = false;
+
+		bankRequirementFields.each(function() {
+			if ( $( this ).prop( "checked" ) ) {
+				billetBankIsRequired = true;
+				return false;
+			}
+		});
+
+		if ( billetBankIsRequired ) {
+			$( billetBankElementId ).attr( 'required', true );
+			return;
+		}
+
+		$( billetBankElementId ).attr( 'required', false );
+  };
 
 	Model.fn.setInstallmentsByFlags = function( event, firstLoad ) {
 		var flags        = this.elements.flagsSelect.val() || [];

--- a/assets/stylesheets/admin/style.css
+++ b/assets/stylesheets/admin/style.css
@@ -64,7 +64,8 @@
   top: 3px;
 }
 
-#mainform .pagarme-field-error {
+#mainform .pagarme-field-error, 
+#mainform select:invalid[id*="woo-pagarme-payments"] + .select2-container > span.selection > span.select2-selection:focus {
   background-color: #f2dede;
   border-color: #ebccd1;
   box-shadow: 1px 1px #ebccd1;

--- a/src/Controller/Gateways.php
+++ b/src/Controller/Gateways.php
@@ -252,6 +252,10 @@ class Gateways extends WC_Payment_Gateway
 			'type'    => 'checkbox',
 			'label'   => __( 'Enables Boleto Bancário', 'woo-pagarme-payments' ),
 			'default' => 'yes',
+			'custom_attributes' => array(
+				'data-action'  => 'enable-billet',
+				'data-requires-field' => 'billet-bank',
+			),
 		);
 	}
 
@@ -272,6 +276,10 @@ class Gateways extends WC_Payment_Gateway
 			'type'    => 'checkbox',
 			'label'   => __( 'Enables Multimethods (Boleto + Credit Card)', 'woo-pagarme-payments' ),
 			'default' => 'no',
+			'custom_attributes' => array(
+				'data-action'  => 'enable-multimethods-billet-card',
+				'data-requires-field' => 'billet-bank',
+			),
 		);
 	}
 
@@ -359,7 +367,7 @@ class Gateways extends WC_Payment_Gateway
 	{
 		return array(
 			'title'       => __( 'Number of Days', 'woo-pagarme-payments' ),
-			'description' => __( '"Expiration days of the boleto after printing."', 'woo-pagarme-payments' ),
+			'description' => __( 'Expiration days of the boleto after printing.', 'woo-pagarme-payments' ),
 			'desc_tip'    => true,
 			'placeholder' => 5,
 			'default'     => 5,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         |   https://mundipagg.atlassian.net/browse/PAA-227
| **What?**         | Currently the plugin allows enabling boleto payments and not filling the bank that will be used, on the admin settings. But on the checkout process, an error is thrown.
| **How?**          | Making the boleto bank (_billet_bank_) field required if the options enabling "boleto" **OR** "boleto + credit card" are checked, not allowing to save the settings.

#### :package: Attachments (if appropriate)
#### Error that was thrown on checkout before the fix
![image](https://user-images.githubusercontent.com/29166727/110021858-06abcf00-7d0a-11eb-91a7-d90ce5828431.png)

#### Behavior on admin settings after the fix (the error message appears according to the browser language)
![image](https://user-images.githubusercontent.com/29166727/110021804-f85db300-7d09-11eb-99c7-b06392fe2fa4.png)
![image](https://user-images.githubusercontent.com/29166727/110021832-fe539400-7d09-11eb-8e61-572e03b57a77.png)
