### PR TITLE
Fixes charge cancellation default amount format

### DIFF
--- a/assets/javascripts/admin/app/component-capture.js
+++ b/assets/javascripts/admin/app/component-capture.js
@@ -64,7 +64,7 @@ MONSTER( 'Pagarme.Components.Capture', function(Model, $, Utils) {
 		$( '.modal' ).iziModal({
 			padding: 20,
 			onOpening: function (modal) {
-				var amount = self.$el.find( '[data-element=amount]' );
+				var amount = modal.$element.find( '[data-element=amount]' );
 				amount.mask( "#.##0,00", { reverse: true } );
 				modal.$element.on( 'click', '[data-action=capture]', self.onClickCapture.bind(self) );
 				modal.$element.on( 'click', '[data-action=cancel]', self.onClickCancel.bind(self) );

--- a/assets/javascripts/admin/built.js
+++ b/assets/javascripts/admin/built.js
@@ -4035,7 +4035,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		$( '.modal' ).iziModal({
 			padding: 20,
 			onOpening: function (modal) {
-				var amount = self.$el.find( '[data-element=amount]' );
+				var amount = modal.$element.find( '[data-element=amount]' );
 				amount.mask( "#.##0,00", { reverse: true } );
 				modal.$element.on( 'click', '[data-action=capture]', self.onClickCapture.bind(self) );
 				modal.$element.on( 'click', '[data-action=cancel]', self.onClickCancel.bind(self) );

--- a/src/Controller/Charges.php
+++ b/src/Controller/Charges.php
@@ -37,7 +37,7 @@ class Charges
 		}
 
 		$charge_id = Utils::post( 'charge_id', false );
-		$amount    = Utils::post( 'amount', 0, 'intval' );
+		$amount    = Utils::post( 'amount', 0 );
 		$mode      = Utils::post( 'mode', false );
 
 		if ( ! $charge_id ) {
@@ -53,7 +53,7 @@ class Charges
 		}
 
 		$resource = new Charges_Resource();
-		$response = $resource->{$mode}( $charge_id, Utils::format_order_price( $amount ) );
+		$response = $resource->{$mode}( $charge_id, Utils::format_desnormalized_order_price( $amount ) );
 
 		error_log( print_r( $response, true ) );
 

--- a/src/View/Orders.php
+++ b/src/View/Orders.php
@@ -92,7 +92,7 @@ class Orders
 			<p><b>PARCIALMENTE CAPTURADO: </b><?php echo $paid_amount; ?></p>
 			<p><b>STATUS: </b><?php echo strtoupper( $item->charge_status ); ?></p>
 			<p>
-				<label>Valor a ser capturado:
+				<label>Valor a ser capturado: R$
 					<input data-element="amount" type="text"/>
 				</label>
 			</p>
@@ -127,7 +127,7 @@ class Orders
 			<p><b>PARCIALMENTE CANCELADO: </b><?php echo $canceled_amount ? Utils::format_order_price_to_view( $canceled_amount ) : '-'; ?></p>
 			<p><b>STATUS: </b><?php echo strtoupper( $item->charge_status ); ?></p>
 			<p>
-				<label>Valor a ser cancelado:
+				<label>Valor a ser cancelado: R$
 					<input data-element="amount" type="text" value="<?php echo $value_to_cancel; ?>"
 					<?php echo $item->charge_status == 'pending' ? 'disabled=disabled' : ''; ?>/>
 				</label>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         |   https://mundipagg.atlassian.net/browse/PAA-220
| **What?**         | On the woocommerce admin, when clicking at the charge cancellation button, the amount is suggested in cents but the cancellation does not work, because the amount must be in BRL (with decimal point or comma, both work), and it is converted after ([on this code](https://github.com/pagarme/woocommerce/blob/master/src/Controller/Charges.php#L56)) to cents before sending to Pagar.me API.
| **How?**          | Using a jquery mask in the amount field, converting amount in cents to amount in BRL. The intention of using the mask already existed in the code, but was not working and I fixed it.

#### NOTE: 
I also found a bug, the cancellation feature was always cancelling only the integer part of the amount, so for example if the charge amount was R$ 45,99 and the user entered 45.99 in the amout field, our plugin cancelled only R$ 45,00. This PR also fixes this bug (on the line 40 of the _src/Controller/Charges.php_ file).

#### :package: Attachments (if appropriate)
#### Before the fix:
![image](https://user-images.githubusercontent.com/29166727/110346444-52ae8a80-800e-11eb-9530-8d321003fe02.png)
![image](https://user-images.githubusercontent.com/29166727/110346494-61953d00-800e-11eb-8949-16794fb411bd.png)


#### After the fix:
![image](https://user-images.githubusercontent.com/29166727/110398933-a7c0bf80-8053-11eb-8e74-0dc8217c4801.png)
![image](https://user-images.githubusercontent.com/29166727/110346729-9a351680-800e-11eb-83d8-9ece585fadf9.png)


