### PR TITLE
Fixes pix setting validation and webhook receipt

### DIFF
--- a/src/Controller/Gateways.php
+++ b/src/Controller/Gateways.php
@@ -386,6 +386,10 @@ class Gateways extends WC_Payment_Gateway
             'desc_tip'    => true,
             'placeholder' => 5,
             'default'     => 5,
+            'custom_attributes' => array(
+                'data-mask'         => '##0',
+                'data-mask-reverse' => 'true',
+            ),
         );
     }
 
@@ -713,6 +717,10 @@ class Gateways extends WC_Payment_Gateway
             'desc_tip'    => true,
             'placeholder' => 3500,
             'default'     => 3500,
+            'custom_attributes' => array(
+                'data-mask'         => '##0',
+                'data-mask-reverse' => 'true',
+            ),
         );
     }
 

--- a/src/Model/Charge.php
+++ b/src/Model/Charge.php
@@ -103,6 +103,8 @@ class Charge
         if (!$webhook_data) {
             return;
         }
+
+        $this->update_core_charge($webhook_data);
         /*
             TODO: remove this insert and update calls. we need to use charge data
             from core's table, and these methods updates the legacy charge table.
@@ -126,20 +128,20 @@ class Charge
                 'charge_id' => esc_sql($webhook_data->data->id),
             )
         );
-
-        $this->update_core_charge($webhook_data);
     }
 
     private function update_core_charge($webhook_data)
     {
-        $webhook_data->data = json_decode(
-            json_encode($webhook_data->data),
+        $webhook = clone $webhook_data;
+
+        $webhook->data = json_decode(
+            json_encode($webhook->data),
             true
         );
 
         $coreWebhookFactory = new WebhookFactory();
         $coreChargeHandler = new ChargeHandlerService();
-        $coreWebhook = $coreWebhookFactory->createFromPostData($webhook_data);
+        $coreWebhook = $coreWebhookFactory->createFromPostData($webhook);
         $coreChargeHandler->handle($coreWebhook);
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issues**           | https://mundipagg.atlassian.net/browse/PAOP-162
| **What?**         | Fixes two problems verified in staging related to pix payments.

**Important Notes**
- Correctly denies user to inform a string for the label "QR code expiration time". During this fix, I've noted that was possible to inform a string in "Number of days" field, that the user can inform the expiration days of the boleto after printing.
- Correctly handles core charge webhooks. The error occurs because the core webhook handling was made after this line of code:https://github.com/pagarme/woocommerce/blob/master/src/Model/Charge.php#L104. Because of that, sometimes the module don't update the core charge table.
