### PR TITLE
chore(sonar): exclude build file from analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,4 +4,4 @@ sonar.projectName=woocommerce
 sonar.projectVersion=1.0
 sonar.sources=.
 sonar.sourceEncoding=UTF-8
-sonar.exclusions=**/.circleci/**, **/.github/**
+sonar.exclusions=**/.circleci/**, **/.github/**, **/built.js


### PR DESCRIPTION
Essa alteração visa fazer com que o Sonar não realize scan dos arquivos `build.js`, evitando duplicação de código.

Problema detectado nessa análise realizada: https://sonarcloud.io/component_measures?branch=feature%2FPAOP-180-implements-reformulation-admin-settings&id=woocommerce&metric=new_lines&view=list

![image](https://user-images.githubusercontent.com/29241659/124653319-8cd05180-de73-11eb-804a-897ec66f72d7.png)
