### PR TITLE
Fixes module activation error and pix additional information

### DIFF
--- a/src/Concrete/WoocommerceCoreSetup.php
+++ b/src/Concrete/WoocommerceCoreSetup.php
@@ -257,7 +257,9 @@ final class WoocommerceCoreSetup extends AbstractModuleCoreSetup
             }
 
             $settingsByBrand = $storeConfig->cc_installments_by_flag;
-            $max = empty($settingsByBrand) ? null : intval($settingsByBrand['max_installment'][$brand]);
+            $max = empty($settingsByBrand)
+                ? null
+                : intval($settingsByBrand['max_installment'][$brand]);
 
             if (!empty($max)) {
                 $initial = Utils::str_to_float($settingsByBrand['interest'][$brand]);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-218
| **What?**         | Fixes module activation error if setting by brand is empty 
| **Why?**          | Because it generated an error when performing an initial installation

 **Important Notes**
- This PR also fixes the error of creating order with pix if the additional pix information is empty or only one information is filled.

Example error:

1) If all additional information is empty

![pix_add_information_error](https://user-images.githubusercontent.com/41760474/124935699-464a3680-dfdc-11eb-9fc8-b873c1fbe6ee.png)

2) If only one is empty

![pix_add_information_error_2](https://user-images.githubusercontent.com/41760474/124936242-bf498e00-dfdc-11eb-89df-4b22a3ed8806.png)

