### PR TITLE
Translate pending to on hold

### DIFF
--- a/src/Concrete/WoocommercePlatformOrderDecorator.php
+++ b/src/Concrete/WoocommercePlatformOrderDecorator.php
@@ -114,7 +114,8 @@ class WoocommercePlatformOrderDecorator extends AbstractPlatformOrderDecorator
     private function getWoocommerceStatusFromCoreStatus($coreStatus)
     {
         $coreToWoocommerceStatus = array(
-            'canceled' => 'cancelled'
+            'canceled' => 'cancelled',
+            'pending' => 'on-hold'
         );
 
         return array_key_exists($coreStatus, $coreToWoocommerceStatus) ?
@@ -124,7 +125,8 @@ class WoocommercePlatformOrderDecorator extends AbstractPlatformOrderDecorator
     private function getCoreStatusFromWoocommerceStatus($woocommerceStatus)
     {
         $woocommerceToCoreStatus = array(
-            'cancelled' => 'canceled'
+            'cancelled' => 'canceled',
+            'on-hold' => 'pending'
         );
 
         return array_key_exists($woocommerceStatus, $woocommerceToCoreStatus) ?


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-245
| **What?**         | Translates core's status "pending" to woocommerce's status "on hold"
| **Why?**         | To clarify to customer the current order status in some scenarios

**Scenarios where order status goes to 'pending payment' incorrectly**
- When canceling a charge of an order that have two charges with 'paid' status.