### PR TITLE
Fix output of canceled value in a charge after changes requested by wordpress.org 

### DIFF
--- a/src/View/Orders.php
+++ b/src/View/Orders.php
@@ -101,7 +101,7 @@ class Orders
             <p><b>CHARGE ID: </b><?php echo esc_html($chargeId); ?></p>
             <p><b>TIPO: </b><?php echo esc_html(strtoupper($transaction->getTransactionType()->getType())); ?></p>
             <p><b>VALOR TOTAL: </b><?php echo Utils::format_order_price_to_view($charge->getAmount()); ?></p>
-            <p><b>PARCIALMENTE CAPTURADO: </b><?php echo esc_html($paid_amount); ?></p>
+            <p><b>PARCIALMENTE CAPTURADO: </b><?php echo wp_kses($paid_amount, ['span' => array('class' => true)]); ?></p>
             <p><b>STATUS: </b><?php echo esc_html(strtoupper($chargeStatus)); ?></p>
             <p>
                 <label>Valor a ser capturado: R$
@@ -121,6 +121,7 @@ class Orders
         $canceled_amount = !empty($charge->getCanceledAmount()) ? $charge->getCanceledAmount() : 0;
         $refunded_amount = !empty($charge->getRefundedAmount()) ? $charge->getRefundedAmount() : 0;
         $paid_amount     = !empty($charge->getPaidAmount()) ? $charge->getPaidAmount() : 0;
+
         $value_to_cancel = $charge->getAmount();
         $chargeId = $charge->getPagarmeId()->getValue();
         $chargeStatus = $charge->getStatus()->getStatus();
@@ -137,13 +138,14 @@ class Orders
             $value_to_cancel = max(0, $paid_amount - $refunded_amount);
         }
 
+        $canceled_amount = !empty($canceled_amount) ? Utils::format_order_price_to_view($canceled_amount) : '-';
     ?>
         <div data-charge-action="<?php echo esc_attr($chargeId); ?>-cancel" data-charge="<?php echo esc_attr($chargeId); ?>" class="modal">
             <h2>Pagar.me - Cancelamento</h2>
             <p><b>CHARGE ID: </b><?php echo esc_html($chargeId); ?></p>
             <p><b>TIPO: </b><?php echo esc_html(strtoupper($transaction->getTransactionType()->getType())); ?></p>
             <p><b>VALOR TOTAL: </b><?php echo Utils::format_order_price_to_view($charge->getAmount()); ?></p>
-            <p><b>PARCIALMENTE CANCELADO: </b><?php echo esc_html($canceled_amount ? Utils::format_order_price_to_view($canceled_amount) : '-'); ?></p>
+            <p><b>PARCIALMENTE CANCELADO: </b><?php echo wp_kses($canceled_amount, ['span' => array('class' => true)]); ?></p>
             <p><b>STATUS: </b><?php echo esc_html(strtoupper($chargeStatus)); ?></p>
             <p>
                 <label>Valor a ser cancelado: R$


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-399
| **What?**         | Fixes canceled value displayed in charge popup after a partial canceled value 
| **Why?**          | To allow user to interact with the module correctly
| **How?**          | Doing the correct output handling.


Before change:

![](https://i.imgur.com/YIWUrpt.jpg)

After change:

![](https://i.imgur.com/V1V6K5D.jpg)
