### PR TITLE
Changes default masks for expiry and card number

### DIFF
--- a/templates/checkout/common-card-item.php
+++ b/templates/checkout/common-card-item.php
@@ -30,7 +30,7 @@ $setting = Setting::get_instance();
 
         <label for="card-number"><?php esc_html_e('Card number', 'woo-pagarme-payments'); ?> <span class="required">*</span></label>
 
-        <input id="card-number" data-element="pagarme-card-number" class="input-text wc-credit-card-form-card-number pagarme-card-form-card-number" data-mask="0000000000000000000" placeholder="•••• •••• •••• ••••" data-required="true" data-pagarmecheckout-element-<?php echo !$suffix ? 1 : esc_html($suffix); ?>="number" style="background-image: none">
+        <input id="card-number" data-element="pagarme-card-number" class="input-text wc-credit-card-form-card-number pagarme-card-form-card-number" data-mask="0000 0000 0000 0000" placeholder="•••• •••• •••• ••••" data-required="true" data-pagarmecheckout-element-<?php echo !$suffix ? 1 : esc_html($suffix); ?>="number" style="background-image: none">
         <input type="hidden" name="brand<?php echo esc_attr($suffix); ?>" data-pagarmecheckout-element-<?php echo !$suffix ? 1 : esc_html($suffix); ?>="brand-input" />
         <span name="brand-image-<?php echo esc_attr(!$suffix ? 1 : $suffix); ?>" pagarme-suffix=<?php echo esc_attr($suffix); ?> data-pagarmecheckout-element-<?php echo !$suffix ? 1 : esc_html($suffix); ?>="brand" data-pagarmecheckout-brand-image-<?php echo !$suffix ? 1 : esc_html($suffix); ?> data-pagarmecheckout-brand-<?php echo !$suffix ? 1 : esc_html($suffix); ?>></span>
     </p>
@@ -42,7 +42,7 @@ $setting = Setting::get_instance();
             <span class="required">*</span>
         </label>
 
-        <input id="card-expiry" data-element="card-expiry" class="input-text wc-credit-card-form-card-expiry pagarme-card-form-card-expiry" data-mask="00/00" data-required="true" placeholder="<?php esc_html_e('MM / YY', 'woo-pagarme-payments'); ?>" data-pagarmecheckout-element-<?php echo !$suffix ? 1 : esc_html($suffix); ?>="exp_date">
+        <input id="card-expiry" data-element="card-expiry" class="input-text wc-credit-card-form-card-expiry pagarme-card-form-card-expiry" data-mask="00 / 00" data-required="true" placeholder="<?php esc_html_e('MM / YY', 'woo-pagarme-payments'); ?>" data-pagarmecheckout-element-<?php echo !$suffix ? 1 : esc_html($suffix); ?>="exp_date">
     </p>
 
     <p class="form-row form-row-last">

--- a/templates/checkout/main.php
+++ b/templates/checkout/main.php
@@ -418,12 +418,15 @@ $swal_data   = array(
                 prop = fields[i].getAttribute('data-pagarmecheckout-element-' + suffix);
                 if (prop === 'exp_date') {
                     var sep = fields[i].getAttribute('data-pagarmecheckout-separator') ? fields[i].getAttribute('data-pagarmecheckout-separator') : '/';
-                    var values = fields[i].value.split(sep);
+                    var values = fields[i].value.replace(/\s/g, '').split(sep);
                     obj['exp_month'] = values[0];
                     obj['exp_year'] = values[1];
                 } else {
                     key = fields[i].value;
 
+                    if (prop == 'number') {
+                        key = key.replace(/\s/g, '');
+                    }
                     if (prop == 'brand') {
                         key = fields[i].getAttribute('data-pagarmecheckout-brand' + suffix);
                     }
@@ -825,8 +828,8 @@ $swal_data   = array(
         };
 
         function addsMask() {
-            $('.pagarme-card-form-card-number').mask('0000000000000000');
-            $('.pagarme-card-form-card-expiry').mask('00/00');
+            $('.pagarme-card-form-card-number').mask('0000 0000 0000 0000');
+            $('.pagarme-card-form-card-expiry').mask('00 / 00');
             $('.pagarme-card-form-card-cvc').mask('0000');
 
             $('#card-order-value').mask('#.##0,00', {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-456
| **What?**         | Changes default mask for expiry and card number fields
| **Why?**          | Because woocommerce have an jquery file that sometimes "force" this masks on our fields, and it makes the buyer unable to inform all digits of card number and expiry date. So we changed the default masks to the ones sometimes forced by woocommerce.

**Important Notes:**
- File that force masks in woocommerce project: https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80[…]/plugins/woocommerce/assets/js/jquery-payment/jquery.payment.js
- Patterns now are "0000 0000 0000 0000" for card number and "00 / 00" for expiry, we remove spaces before send requests to mark1