### PR TITLE
bugfix: card number field brand api requests

### DIFF
--- a/assets/javascripts/front/checkout/model/payment/card.js
+++ b/assets/javascripts/front/checkout/model/payment/card.js
@@ -500,7 +500,7 @@ let pagarmeCard = {
             pagarmeCard.preventSpecialCharacter(this);
         });
 
-        jQuery(this.cardNumberTarget).on('input', function (event) {
+        jQuery(this.cardNumberTarget).on('change', function (event) {
             pagarmeCard.keyEventHandlerCard(event);
         });
 
@@ -509,7 +509,7 @@ let pagarmeCard = {
         });
     },
     renewEventListener: function () {
-        jQuery(this.cardNumberTarget).on('input', function (event) {
+        jQuery(this.cardNumberTarget).on('change', function (event) {
             pagarmeCard.keyEventHandlerCard(event);
         });
         jQuery(`${this.fieldsetCardElements} input`).on('change', function () {


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
No **checkout antigo**, estavamos fazendo requests seguidas na API da bandeira de cartão, para cada dígito a partir do sexto, ao digitar o número do cartão. Essa requisição fazia com que a digitação ficasse lenta, pois o campo aguardava a resposta da API, a cada número adicional, antes de inserir o número digitado no campo.

Isso ocorria devido a chamada da função ter sido alterada para o evento "on input" na última atualização. Voltei a chamada da função para o evento "on change".


### Cenários testados
No checkout antigo, o campo não está fazendo mais as requisições a cada dígito, e a lentidão não ocorre mais.
