### PR TITLE
Develop

### DIFF
--- a/assets/javascripts/front/checkout/model/payment/card.js
+++ b/assets/javascripts/front/checkout/model/payment/card.js
@@ -562,4 +562,4 @@ let pagarmeCard = {
         this.onChangeBillingCpf();
     }
 };
-pagarmeCard.start();
+pagarmeCard.start(); 

--- a/assets/javascripts/front/checkout/model/payment/card.js
+++ b/assets/javascripts/front/checkout/model/payment/card.js
@@ -45,14 +45,14 @@ let pagarmeCard = {
     },
     isPagarmePayment: function () {
         const selectedPayment = pagarmeCard.getSelectedPaymentMethod();
-        if(selectedPayment.length <= 0) {
+        if (selectedPayment.length <= 0) {
             return false;
         }
         const selectedPaymentVal = selectedPayment.val();
-        if(!selectedPaymentVal) {
+        if (!selectedPaymentVal) {
             return false;
         }
-        if(selectedPaymentVal.indexOf('pagarme') === -1) {
+        if (selectedPaymentVal.indexOf('pagarme') === -1) {
             return false;
         }
         return selectedPaymentVal.indexOf('pagarme');
@@ -63,7 +63,7 @@ let pagarmeCard = {
         }
 
         const selectedIsPagarmeCard = pagarmeCard.getSelectedPaymentMethod().val().indexOf('card');
-        if(selectedIsPagarmeCard === -1) {
+        if (selectedIsPagarmeCard === -1) {
             return false;
         }
 
@@ -74,7 +74,7 @@ let pagarmeCard = {
         const regex = /[^a-z ]/gi;
         const val = jQuery(element).val();
 
-        if(regex.test(val)) {
+        if (regex.test(val)) {
             jQuery(element).val(val.replace(regex, ''));
             selectionStart--;
         }
@@ -252,7 +252,7 @@ let pagarmeCard = {
         if (doesNotHaveBrand) {
             pagarmeCard.showErrorInPaymentMethod(
                 PagarmeGlobalVars.checkoutErrors.pt_BR[
-                    'invalidBrand'
+                'invalidBrand'
                 ]
             );
             return;
@@ -344,7 +344,7 @@ let pagarmeCard = {
                 }
             });
             ajax.done(function (response) {
-                pagarmeCard._done(select, info, storageName, cardForm, JSON.parse(response));
+                pagarmeCard._done(select, info, storageName, cardForm, response);
             });
             ajax.fail(function () {
                 pagarmeCard._fail(cardForm);
@@ -357,7 +357,7 @@ let pagarmeCard = {
     _done: function (select, info, storageName, event, response) {
         if (info.length) {
             info.addClass('pagarme-hidden');
-            if(response.installmentsConfig > 1) {
+            if (response.installmentsConfig > 1) {
                 info.removeClass('pagarme-hidden');
             }
         }
@@ -373,7 +373,7 @@ let pagarmeCard = {
 
         if (typeof formattedEvent.unblock === 'function') {
             formattedEvent.unblock();
-           return;
+            return;
         }
 
         if (typeof jQuery.unblockUI === 'function') {
@@ -391,7 +391,7 @@ let pagarmeCard = {
                     opacity: 0.6
                 }
             });
-           return;
+            return;
         }
 
         if (typeof jQuery.blockUI === 'function') {
@@ -477,7 +477,7 @@ let pagarmeCard = {
         pagarmeTokenize.execute();
         pagarmeCard.execute(event);
     },
-    brandIsVisaOrMaster: function() {
+    brandIsVisaOrMaster: function () {
         const checkoutPaymentElement = this.getCheckoutPaymentElement();
         const brand = jQuery(checkoutPaymentElement).find(this.brandTarget)
             .val();

--- a/src/Controller/Checkout.php
+++ b/src/Controller/Checkout.php
@@ -80,12 +80,17 @@ class Checkout
 
         );
         $optionsHtml = $this->cardInstallments->renderOptions($installments);
-        echo json_encode([
+        
+        // Ensure no previous output contaminates the JSON response
+        if (ob_get_length()) {
+            ob_clean();
+        }
+        
+        wp_send_json([
             'installmentsConfig' => $installmentsConfig,
             'optionsHtml' => wp_kses_no_null($optionsHtml),
             'installments' => $installments
         ]);
-        exit();
     }
 
     public function parse_cards($data, $key = 'card')

--- a/src/Controller/Webhooks.php
+++ b/src/Controller/Webhooks.php
@@ -61,7 +61,10 @@ class Webhooks
             $this->config->log()->info('Webhook Received: empty body!');
             return;
         }
-        if (!$this->orderByWoocommerce($body->data->code, $body->data->order->metadata, $body->id) ) {
+        $code = $body->data->code ?? null;
+        $metadata = $body->data->order->metadata ?? null;
+
+        if (!$this->orderByWoocommerce($code, $metadata, $body->id) ) {
             return;
         }
 


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Este PR agrupa correções críticas para a estabilidade do módulo no checkout e no processamento de webhooks.

**1. Correções no Checkout (Installments Ajax):**
- **Sintoma:** Ocorria erro `SyntaxError` ao carregar as parcelas do cartão ("Unexpected token <" ou "[object Object] is not valid JSON").
- **Backend ([Checkout.php](cci:7://file:///home/mario/pagarme-woocommerce/src/Controller/Checkout.php:0:0-0:0)):** Substituído `echo json_encode(...)` + `exit()` por `ob_clean()` + `wp_send_json(...)`. Isso garante que o buffer de saída esteja limpo antes de enviar a resposta, evitando que notices PHP ou HTML alheio quebrem o JSON, além de enviar o header `Content-Type: application/json` correto.
- **Frontend ([card.js](cci:7://file:///home/mario/pagarme-woocommerce/assets/javascripts/front/checkout/model/payment/card.js:0:0-0:0)):** Removido o `JSON.parse(response)` na callback do jQuery. Como o backend agora retorna o header JSON correto, o jQuery já entrega o payload parseado (como Objeto). O `JSON.parse` redundante forçava a conversão para string "[object Object]" causando o erro.

**[BÔNUS] Correção no Webhook (`Webhooks.php`):**
- **Sintoma:** Erro *"Attempt to read property metadata on null"* ao receber webhooks.
- **Correção:** Adicionada validação de *null coalescing* (`?? null`) ao acessar `$body->data->code` e `$body->data->order->metadata`, prevenindo erros fatais quando o payload do webhook não traz esses dados.