### PR TITLE
Feat/add one stone entities in model config ecpj 451

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
   <testsuites>
     <testsuite name="Package Test Suite">
       <directory suffix=".php">./tests/</directory>
+      <exclude>./tests/bootstrap.php</exclude>
     </testsuite>
   </testsuites>
   <source>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <php>
     <const name="ABSPATH" value="/tmp/wordpress/"/>
   </php>

--- a/src/Block/Adminhtml/Sales/Order/MetaBox/ChargeActions.php
+++ b/src/Block/Adminhtml/Sales/Order/MetaBox/ChargeActions.php
@@ -113,11 +113,11 @@ class ChargeActions extends AbstractMetaBox implements MetaBoxInterface
 
     public function getChargeUrl($chargeID)
     {
-        if (!$this->config->isDashConfigAccessible()) {
+        if (!$this->config->isPagarmeDashConfigAccessible()) {
             return false;
         }
 
-        return $this->config->getDashUrl() . 'charges/' . $chargeID;
+        return $this->config->getPagarmeDashUrl() . 'charges/' . $chargeID;
     }
 
     /**

--- a/src/Block/Adminhtml/Sales/Order/MetaBox/ChargeActions.php
+++ b/src/Block/Adminhtml/Sales/Order/MetaBox/ChargeActions.php
@@ -113,7 +113,7 @@ class ChargeActions extends AbstractMetaBox implements MetaBoxInterface
 
     public function getChargeUrl($chargeID)
     {
-        if (!$this->config->isAccAndMerchSaved()) {
+        if (!$this->config->isDashConfigAccessible()) {
             return false;
         }
 

--- a/src/Block/Adminhtml/System/Config/Form/Field/Hub/Integration.php
+++ b/src/Block/Adminhtml/System/Config/Form/Field/Hub/Integration.php
@@ -52,6 +52,6 @@ class Integration extends AbstractField
      */
     public function userCanDesintegrate()
     {
-        return Utils::isCurrentUserAdmin() && $this->config->isAccAndMerchSaved();
+        return Utils::isCurrentUserAdmin() && $this->config->isDashConfigAccessible();
     }
 }

--- a/src/Block/Adminhtml/System/Config/Form/Field/Hub/Integration.php
+++ b/src/Block/Adminhtml/System/Config/Form/Field/Hub/Integration.php
@@ -52,6 +52,6 @@ class Integration extends AbstractField
      */
     public function userCanDesintegrate()
     {
-        return Utils::isCurrentUserAdmin() && $this->config->isDashConfigAccessible();
+        return Utils::isCurrentUserAdmin() && $this->config->isPagarmeDashConfigAccessible();
     }
 }

--- a/src/Controller/Gateways/AbstractGateway.php
+++ b/src/Controller/Gateways/AbstractGateway.php
@@ -133,7 +133,9 @@ abstract class AbstractGateway extends WC_Payment_Gateway
         $this->yesnoOptions = $yesnoOptions ?? new Yesno;
         $this->method_title = $this->getPaymentMethodTitle();
         $this->method_description = __('Payment Gateway Pagar.me', 'woo-pagarme-payments') . ' ' . $this->method_title;
-        $this->view_transaction_url = $this->config->getPagarmeDashUrl() . 'orders/%s';
+        $this->view_transaction_url = $this->config->getPagarmeDashUrl()
+            ? $this->config->getPagarmeDashUrl() . 'orders/%s'
+            : null;
         $this->has_fields = false;
         $this->init_form_fields();
         $this->init_settings();

--- a/src/Controller/Gateways/AbstractGateway.php
+++ b/src/Controller/Gateways/AbstractGateway.php
@@ -133,7 +133,7 @@ abstract class AbstractGateway extends WC_Payment_Gateway
         $this->yesnoOptions = $yesnoOptions ?? new Yesno;
         $this->method_title = $this->getPaymentMethodTitle();
         $this->method_description = __('Payment Gateway Pagar.me', 'woo-pagarme-payments') . ' ' . $this->method_title;
-        $this->view_transaction_url = $this->config->getDashUrl() . 'orders/%s';
+        $this->view_transaction_url = $this->config->getPagarmeDashUrl() . 'orders/%s';
         $this->has_fields = false;
         $this->init_form_fields();
         $this->init_settings();

--- a/src/Controller/HubAccounts.php
+++ b/src/Controller/HubAccounts.php
@@ -136,7 +136,7 @@ class HubAccounts
     private function getHubNoticeButtons($dashPage)
     {
         $buttons = [];
-        $dashUrl = $this->config->getDashUrl();
+        $dashUrl = $this->config->getPagarmeDashUrl();
         if ($dashUrl) {
             $dashUrl .= "settings/{$dashPage}/";
             $buttons[] = wcmpSingleButtonArray(

--- a/src/Controller/Settings.php
+++ b/src/Controller/Settings.php
@@ -80,7 +80,7 @@ class Settings
             add_action('woocommerce_payment_gateways_setting_column_subscription_payments_toggles', array($this, 'populate_subscription_payments_toggles_column'));
             add_action('wp_ajax_pagarme_toggle_payment_subscription', array($this, 'pagarme_toggle_payment_subscription'));
         }
-        
+
         if (Utils::isCheckoutBlocksActive()){
             add_filter('woocommerce_payment_gateways_setting_columns', array($this, 'checkoutblocks_status_column'));
             add_action('woocommerce_payment_gateways_setting_column_checkoutblocks_status', array($this, 'populate_checkoutblocks_status_column'));
@@ -135,7 +135,7 @@ class Settings
             ]
         ];
 
-        if ($this->config->isAccAndMerchSaved()){
+        if ($this->config->isDashConfigAccessible()){
             $fields[] = [
                 'fieldObject' => Environment::class,
                 'id' => 'hub_environment',

--- a/src/Controller/Settings.php
+++ b/src/Controller/Settings.php
@@ -135,7 +135,7 @@ class Settings
             ]
         ];
 
-        if ($this->config->isDashConfigAccessible()){
+        if ($this->config->isPagarmeDashConfigAccessible()){
             $fields[] = [
                 'fieldObject' => Environment::class,
                 'id' => 'hub_environment',

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -31,6 +31,9 @@ defined('ABSPATH') || exit;
 class Config extends DataObject
 {
     const ENABLED = 'yes';
+    const ACCOUNT_ID = 'account_id';
+    const PAYMENT_PROFILE_ID = 'payment_profile_id';
+    const POI_TYPE = 'poi_type';
 
     /** @var string */
     const HUB_SANDBOX_ENVIRONMENT = 'Sandbox';
@@ -207,7 +210,7 @@ class Config extends DataObject
 
     public function setAccountId($accountId)
     {
-        $this->setData('account_id', $accountId);
+        $this->setData(Config::ACCOUNT_ID, $accountId);
         $this->updateGooglepayAccountId($accountId);
     }
 
@@ -216,7 +219,7 @@ class Config extends DataObject
      */
     public function getPaymentProfileId()
     {
-        return $this->getData('payment_profile_id');
+        return $this->getData(Config::PAYMENT_PROFILE_ID);
     }
 
     /**
@@ -224,7 +227,7 @@ class Config extends DataObject
      */
     public function setPaymentProfileId($paymentProfileId)
     {
-        $this->setData('payment_profile_id', $paymentProfileId);
+        $this->setData(Config::PAYMENT_PROFILE_ID, $paymentProfileId);
     }
 
     /**
@@ -232,7 +235,7 @@ class Config extends DataObject
      */
     public function getPoiType()
     {
-        return $this->getData('poi_type');
+        return $this->getData(Config::POI_TYPE);
     }
 
     /**
@@ -240,7 +243,7 @@ class Config extends DataObject
      */
     public function setPoiType($poiType)
     {
-        $this->setData('poi_type', $poiType);
+        $this->setData(Config::POI_TYPE, $poiType);
     }
 
     /**
@@ -424,7 +427,7 @@ class Config extends DataObject
     {
         $googlepayOption = get_option('woocommerce_woo-pagarme-payments-googlepay_settings');
         if (is_array($googlepayOption)) {
-            $googlepayOption['account_id'] = $accountId;
+            $googlepayOption[Config::ACCOUNT_ID] = $accountId;
             update_option('woocommerce_woo-pagarme-payments-googlepay_settings', $googlepayOption);
         }
     }

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -200,10 +200,9 @@ class Config extends DataObject
     /**
      * @return bool
      */
-    public function isDashConfigAccessible(): bool
+    public function isPagarmeDashConfigAccessible(): bool
     {
-        return $this->getPaymentProfileId()
-            || ($this->getMerchantId() && $this->getAccountId());
+        return $this->getMerchantId() && $this->getAccountId();
     }
 
     public function setAccountId($accountId)
@@ -255,9 +254,9 @@ class Config extends DataObject
     /**
      * @return mixed
      */
-    public function getDashUrl()
+    public function getPagarmeDashUrl()
     {
-        if (!$this->isDashConfigAccessible()) {
+        if (!$this->isPagarmeDashConfigAccessible()) {
             return null;
         }
         return sprintf(

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -7,21 +7,22 @@
  * @link        https://pagar.me
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace Woocommerce\Pagarme\Model;
 
-use Woocommerce\Pagarme\Core;
-use Pagarme\Core\Kernel\Services\MoneyService;
-use Woocommerce\Pagarme\Model\Data\DataObject;
-use Pagarme\Core\Middle\Model\Account\PaymentEnum;
 use Pagarme\Core\Hub\Services\HubIntegrationService;
-use Woocommerce\Pagarme\Model\Serialize\Serializer\Json;
-use Woocommerce\Pagarme\Model\Config\Source\EnvironmentsTypes;
-use Woocommerce\Pagarme\Model\Config\PagarmeCoreConfigManagement;
+use Pagarme\Core\Kernel\Services\MoneyService;
+use Pagarme\Core\Middle\Model\Account\PaymentEnum;
+use WC_Logger;
 use Woocommerce\Pagarme\Concrete\WoocommerceCoreSetup as CoreSetup;
+use Woocommerce\Pagarme\Core;
+use Woocommerce\Pagarme\Model\Config\PagarmeCoreConfigManagement;
+use Woocommerce\Pagarme\Model\Config\Source\EnvironmentsTypes;
+use Woocommerce\Pagarme\Model\Data\DataObject;
+use Woocommerce\Pagarme\Model\Serialize\Serializer\Json;
 
-defined( 'ABSPATH' ) || exit;
+defined('ABSPATH') || exit;
 
 /**
  * Class Config
@@ -63,7 +64,7 @@ class Config extends DataObject
             }
             add_action(
                 'update_option_' . $this->getOptionKey(),
-                [ $this, 'updateOption' ],
+                [$this, 'updateOption'],
                 10, 3
             );
         }
@@ -127,7 +128,7 @@ class Config extends DataObject
      */
     public function getIsSandboxMode()
     {
-        return ( $this->getHubEnvironment() === static::HUB_SANDBOX_ENVIRONMENT ||
+        return ($this->getHubEnvironment() === static::HUB_SANDBOX_ENVIRONMENT ||
             strpos(($this->getProductionSecretKey()) ?? '', 'sk_test') !== false ||
             strpos(($this->getProductionPublicKey()) ?? '', 'pk_test') !== false
         );
@@ -199,8 +200,10 @@ class Config extends DataObject
     /**
      * @return bool
      */
-    public function isAccAndMerchSaved() : bool {
-        return $this->getMerchantId() && $this->getAccountId();
+    public function isDashConfigAccessible(): bool
+    {
+        return $this->getPaymentProfileId()
+            || ($this->getMerchantId() && $this->getAccountId());
     }
 
     public function setAccountId($accountId)
@@ -210,10 +213,51 @@ class Config extends DataObject
     }
 
     /**
+     * @return string|null
+     */
+    public function getPaymentProfileId()
+    {
+        return $this->getData('payment_profile_id');
+    }
+
+    /**
+     * @param string $paymentProfileId
+     */
+    public function setPaymentProfileId($paymentProfileId)
+    {
+        $this->setData('payment_profile_id', $paymentProfileId);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPoiType()
+    {
+        return $this->getData('poi_type');
+    }
+
+    /**
+     * @param string $poiType
+     */
+    public function setPoiType($poiType)
+    {
+        $this->setData('poi_type', $poiType);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOneStoneEnabled(): bool
+    {
+        return !empty($this->getPaymentProfileId());
+    }
+
+    /**
      * @return mixed
      */
-    public function getDashUrl() {
-        if (!$this->isAccAndMerchSaved()) {
+    public function getDashUrl()
+    {
+        if (!$this->isDashConfigAccessible()) {
             return null;
         }
         return sprintf(
@@ -311,7 +355,7 @@ class Config extends DataObject
 
         return
             $type === CardInstallments::INSTALLMENTS_FOR_ALL_FLAGS
-            ||  $type === CardInstallments::INSTALLMENTS_LEGACY;
+            || $type === CardInstallments::INSTALLMENTS_LEGACY;
     }
 
     public function getInstallmentType()
@@ -368,7 +412,7 @@ class Config extends DataObject
         if (is_string($tdsMinAmount) && ctype_digit($tdsMinAmount)) {
             return intval($tdsMinAmount);
         }
-        if(is_int($tdsMinAmount)) {
+        if (is_int($tdsMinAmount)) {
             return $tdsMinAmount;
         }
 
@@ -379,10 +423,10 @@ class Config extends DataObject
 
     private function updateGooglepayAccountId($accountId)
     {
-        $googlepayOption = get_option( 'woocommerce_woo-pagarme-payments-googlepay_settings' );
-        if(is_array($googlepayOption)) {
+        $googlepayOption = get_option('woocommerce_woo-pagarme-payments-googlepay_settings');
+        if (is_array($googlepayOption)) {
             $googlepayOption['account_id'] = $accountId;
-            update_option( 'woocommerce_woo-pagarme-payments-googlepay_settings', $googlepayOption );
+            update_option('woocommerce_woo-pagarme-payments-googlepay_settings', $googlepayOption);
         }
     }
 
@@ -411,7 +455,7 @@ class Config extends DataObject
 
     public function log()
     {
-        return new \WC_Logger();
+        return new WC_Logger();
     }
 
     /**
@@ -422,5 +466,4 @@ class Config extends DataObject
     {
         return $this->getData($configKey) === self::ENABLED;
     }
-
 }

--- a/templates/adminhtml/system/config/form/field/hub/dash.phtml
+++ b/templates/adminhtml/system/config/form/field/hub/dash.phtml
@@ -13,8 +13,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<?php if ($this->config->isDashConfigAccessible()) : ?>
-    <a href="<?= $this->config->getDashUrl(); ?>" target="_blank" rel="noopener"
+<?php if ($this->config->isPagarmeDashConfigAccessible()) : ?>
+    <a href="<?= $this->config->getPagarmeDashUrl(); ?>" target="_blank" rel="noopener"
        class="button button-secondary pagarme-access-dash-btn">
         <?= __('Access Pagar.me Dash', 'woo-pagarme-payments'); ?>
         <img alt="Pagarme Avatar"

--- a/templates/adminhtml/system/config/form/field/hub/dash.phtml
+++ b/templates/adminhtml/system/config/form/field/hub/dash.phtml
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 ?>
-<?php if ($this->config->isAccAndMerchSaved()) : ?>
+<?php if ($this->config->isDashConfigAccessible()) : ?>
     <a href="<?= $this->config->getDashUrl(); ?>" target="_blank" rel="noopener"
        class="button button-secondary pagarme-access-dash-btn">
         <?= __('Access Pagar.me Dash', 'woo-pagarme-payments'); ?>

--- a/templates/adminhtml/system/config/form/field/hub/environment.phtml
+++ b/templates/adminhtml/system/config/form/field/hub/environment.phtml
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 ?>
-<?php if ($this->config->isAccAndMerchSaved()) : ?>
+<?php if ($this->config->isDashConfigAccessible()) : ?>
     <p>
         <?php echo esc_attr($this->getCurrent()); ?>
         <?php if ($this->config->getHubInstallId() &&

--- a/templates/adminhtml/system/config/form/field/hub/environment.phtml
+++ b/templates/adminhtml/system/config/form/field/hub/environment.phtml
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 ?>
-<?php if ($this->config->isDashConfigAccessible()) : ?>
+<?php if ($this->config->isPagarmeDashConfigAccessible()) : ?>
     <p>
         <?php echo esc_attr($this->getCurrent()); ?>
         <?php if ($this->config->getHubInstallId() &&

--- a/tests/Concrete/WoocommerceCoreSetupTest.php
+++ b/tests/Concrete/WoocommerceCoreSetupTest.php
@@ -36,11 +36,9 @@ class WoocommerceCoreSetupTest extends TestCase
 
     public function testMarketplaceConfigWithCallFilter()
     {
-        // Mock da variável global $wp_filter para simular a existência do filtro
         global $wp_filter;
         $wp_filter['pagarme_marketplace_config'] = true;
 
-        // Mock do apply_filters para simular o filtro sendo aplicado
         Brain\Monkey\Functions\when('apply_filters')
             ->alias(function($filter, $value, ...$args) {
                 if ($filter === 'pagarme_marketplace_config' && $value !== null) {
@@ -52,7 +50,6 @@ class WoocommerceCoreSetupTest extends TestCase
         $configMock = $this->getMockForConfiguration();
         $this->assertInstanceOf(MarketplaceConfig::class, $configMock->getModuleConfiguration()->getMarketplaceConfig());
 
-        // Limpar a variável global após o teste
         unset($wp_filter['pagarme_marketplace_config']);
     }
 

--- a/tests/Concrete/WoocommerceCoreSetupTest.php
+++ b/tests/Concrete/WoocommerceCoreSetupTest.php
@@ -2,6 +2,7 @@
 
 namespace Woocommerce\Pagarme\Tests\Concrete;
 
+use Brain;
 use Pagarme\Core\Kernel\Services\InstallmentService;
 use PHPUnit\Framework\TestCase;
 use Woocommerce\Pagarme\Concrete\WoocommerceCoreSetup;
@@ -14,25 +15,34 @@ use Pagarme\Core\Kernel\ValueObjects\Configuration\MarketplaceConfig;
  */
 class WoocommerceCoreSetupTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Brain\Monkey\setUp();
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();
+        Brain\Monkey\tearDown();
+        parent::tearDown();
     }
 
     public function testMarketplaceConfigWithoutCallFilter()
     {
-        require_once("vendor/wordpress/wordpress/src/wp-includes/plugin.php");
         $configMock = $this->getMockForConfiguration();
         $this->assertNull($configMock->getModuleConfiguration()->getMarketplaceConfig());
     }
 
     public function testMarketplaceConfigWithCallFilter()
     {
-        require_once("vendor/wordpress/wordpress/src/wp-includes/plugin.php");
-        add_filter('pagarme_marketplace_config', function($object){
-            $object->mainRecipientId = "re_xxxxxxxxx0x00000xxxx000xx";
-            return $object;
-        });
+        Brain\Monkey\Filters\expectApplied('pagarme_marketplace_config')
+            ->once()
+            ->andReturnUsing(function($object) {
+                $object->mainRecipientId = "re_xxxxxxxxx0x00000xxxx000xx";
+                return $object;
+            });
+
         $configMock = $this->getMockForConfiguration();
         $this->assertInstanceOf(MarketplaceConfig::class, $configMock->getModuleConfiguration()->getMarketplaceConfig());
     }

--- a/tests/Concrete/WoocommerceCoreSetupTest.php
+++ b/tests/Concrete/WoocommerceCoreSetupTest.php
@@ -36,11 +36,13 @@ class WoocommerceCoreSetupTest extends TestCase
 
     public function testMarketplaceConfigWithCallFilter()
     {
-        Brain\Monkey\Filters\expectApplied('pagarme_marketplace_config')
-            ->once()
-            ->andReturnUsing(function($object) {
-                $object->mainRecipientId = "re_xxxxxxxxx0x00000xxxx000xx";
-                return $object;
+        // Mock do apply_filters para simular o filtro sendo aplicado
+        Brain\Monkey\Functions\when('apply_filters')
+            ->alias(function($filter, $value, ...$args) {
+                if ($filter === 'pagarme_marketplace_config' && $value !== null) {
+                    $value->mainRecipientId = "re_xxxxxxxxx0x00000xxxx000xx";
+                }
+                return $value;
             });
 
         $configMock = $this->getMockForConfiguration();

--- a/tests/Concrete/WoocommerceCoreSetupTest.php
+++ b/tests/Concrete/WoocommerceCoreSetupTest.php
@@ -36,6 +36,10 @@ class WoocommerceCoreSetupTest extends TestCase
 
     public function testMarketplaceConfigWithCallFilter()
     {
+        // Mock da variável global $wp_filter para simular a existência do filtro
+        global $wp_filter;
+        $wp_filter['pagarme_marketplace_config'] = true;
+
         // Mock do apply_filters para simular o filtro sendo aplicado
         Brain\Monkey\Functions\when('apply_filters')
             ->alias(function($filter, $value, ...$args) {
@@ -47,6 +51,9 @@ class WoocommerceCoreSetupTest extends TestCase
 
         $configMock = $this->getMockForConfiguration();
         $this->assertInstanceOf(MarketplaceConfig::class, $configMock->getModuleConfiguration()->getMarketplaceConfig());
+
+        // Limpar a variável global após o teste
+        unset($wp_filter['pagarme_marketplace_config']);
     }
 
     private function getMockForConfiguration()

--- a/tests/Concrete/WoocommercePlatformOrderDecoratorTest.php
+++ b/tests/Concrete/WoocommercePlatformOrderDecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Woocommerce\Pagarme\Tests\Concrete;
 
+use Brain;
 use Mockery;
 use WC_Order;
 use PHPUnit\Framework\TestCase;
@@ -17,9 +18,17 @@ use Pagarme\Core\Payment\Aggregates\Payments\AbstractCreditCardPayment;
  */
 class WoocommercePlatformOrderDecoratorTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        Brain\Monkey\setUp();
+    }
+
     public function tearDown(): void
     {
         Mockery::close();
+        Brain\Monkey\tearDown();
+        parent::tearDown();
     }
 
     public function testGetPaymentMethodCollectionWithTdsAuthenticatedCreditCardPaymentMethodShouldSetAuthenticationNode()
@@ -71,10 +80,11 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
 
     public function testHandleSplitOrderWithCallFilter()
     {
-        require_once("vendor/wordpress/wordpress/src/wp-includes/plugin.php");
         $platformOrderDecorator = $this->returnBasicPlatformOrderDecorator();
-        add_filter('pagarme_split_order', function($order, $paymentMethod){
-            return [
+
+        Brain\Monkey\Filters\expectApplied('pagarme_split_order')
+            ->once()
+            ->andReturn([
                 'sellers' => [
                     [
                         'marketplaceCommission' => 400,
@@ -85,8 +95,8 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
                 'marketplace' => [
                     'totalCommission' => 400
                 ]
-            ];
-        }, 10, 2);
+            ]);
+
         $splitReturn = $platformOrderDecorator->handleSplitOrder();
         $this->assertInstanceOf(Split::class, $splitReturn);
     }
@@ -94,10 +104,12 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
     public function testHandleSplitOrderWithWrongCallFilter()
     {
         $this->expectException(\InvalidArgumentException::class);
-        require_once("vendor/wordpress/wordpress/src/wp-includes/plugin.php");
+
         $platformOrderDecorator = $this->returnBasicPlatformOrderDecorator();
-        add_filter('pagarme_split_order', function($order, $paymentMethod){
-            return [
+
+        Brain\Monkey\Filters\expectApplied('pagarme_split_order')
+            ->once()
+            ->andReturn([
                 'sellers' => [
                     [
                         'commission'            => 800,
@@ -107,11 +119,11 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
                 'marketplace' => [
                     'totalCommission' => 400
                 ]
-            ];
-        }, 10, 2);
+            ]);
+
         $platformOrderDecorator->handleSplitOrder();
     }
-    
+
 
     private function returnBasicPlatformOrderDecorator()
     {

--- a/tests/Concrete/WoocommercePlatformOrderDecoratorTest.php
+++ b/tests/Concrete/WoocommercePlatformOrderDecoratorTest.php
@@ -80,6 +80,10 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
 
     public function testHandleSplitOrderWithCallFilter()
     {
+        // Mock da variável global $wp_filter para simular a existência do filtro
+        global $wp_filter;
+        $wp_filter['pagarme_split_order'] = true;
+
         $platformOrderDecorator = $this->returnBasicPlatformOrderDecorator();
 
         // Mock do apply_filters para simular o filtro sendo aplicado
@@ -104,11 +108,18 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
 
         $splitReturn = $platformOrderDecorator->handleSplitOrder();
         $this->assertInstanceOf(Split::class, $splitReturn);
+
+        // Limpar a variável global após o teste
+        unset($wp_filter['pagarme_split_order']);
     }
 
     public function testHandleSplitOrderWithWrongCallFilter()
     {
         $this->expectException(\InvalidArgumentException::class);
+
+        // Mock da variável global $wp_filter para simular a existência do filtro
+        global $wp_filter;
+        $wp_filter['pagarme_split_order'] = true;
 
         $platformOrderDecorator = $this->returnBasicPlatformOrderDecorator();
 
@@ -132,7 +143,12 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
                 return $value;
             });
 
-        $platformOrderDecorator->handleSplitOrder();
+        try {
+            $platformOrderDecorator->handleSplitOrder();
+        } finally {
+            // Limpar a variável global após o teste
+            unset($wp_filter['pagarme_split_order']);
+        }
     }
 
 

--- a/tests/Concrete/WoocommercePlatformOrderDecoratorTest.php
+++ b/tests/Concrete/WoocommercePlatformOrderDecoratorTest.php
@@ -80,13 +80,11 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
 
     public function testHandleSplitOrderWithCallFilter()
     {
-        // Mock da variável global $wp_filter para simular a existência do filtro
         global $wp_filter;
         $wp_filter['pagarme_split_order'] = true;
 
         $platformOrderDecorator = $this->returnBasicPlatformOrderDecorator();
 
-        // Mock do apply_filters para simular o filtro sendo aplicado
         Brain\Monkey\Functions\when('apply_filters')
             ->alias(function($filter, $value, ...$args) {
                 if ($filter === 'pagarme_split_order') {
@@ -109,7 +107,6 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
         $splitReturn = $platformOrderDecorator->handleSplitOrder();
         $this->assertInstanceOf(Split::class, $splitReturn);
 
-        // Limpar a variável global após o teste
         unset($wp_filter['pagarme_split_order']);
     }
 
@@ -117,13 +114,11 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        // Mock da variável global $wp_filter para simular a existência do filtro
         global $wp_filter;
         $wp_filter['pagarme_split_order'] = true;
 
         $platformOrderDecorator = $this->returnBasicPlatformOrderDecorator();
 
-        // Mock do apply_filters para simular o filtro retornando dados inválidos
         Brain\Monkey\Functions\when('apply_filters')
             ->alias(function($filter, $value, ...$args) {
                 if ($filter === 'pagarme_split_order') {
@@ -132,7 +127,6 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
                             [
                                 'commission'            => 800,
                                 'pagarmeId'             => "re_xxxxxxxxxxxxxxx"
-                                // Faltando 'marketplaceCommission' - isso deve causar InvalidArgumentException
                             ]
                         ],
                         'marketplace' => [
@@ -146,7 +140,6 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
         try {
             $platformOrderDecorator->handleSplitOrder();
         } finally {
-            // Limpar a variável global após o teste
             unset($wp_filter['pagarme_split_order']);
         }
     }

--- a/tests/Concrete/WoocommercePlatformOrderDecoratorTest.php
+++ b/tests/Concrete/WoocommercePlatformOrderDecoratorTest.php
@@ -82,20 +82,25 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
     {
         $platformOrderDecorator = $this->returnBasicPlatformOrderDecorator();
 
-        Brain\Monkey\Filters\expectApplied('pagarme_split_order')
-            ->once()
-            ->andReturn([
-                'sellers' => [
-                    [
-                        'marketplaceCommission' => 400,
-                        'commission'            => 800,
-                        'pagarmeId'             => "re_xxxxxxxxxxxxxxx"
-                    ]
-                ],
-                'marketplace' => [
-                    'totalCommission' => 400
-                ]
-            ]);
+        // Mock do apply_filters para simular o filtro sendo aplicado
+        Brain\Monkey\Functions\when('apply_filters')
+            ->alias(function($filter, $value, ...$args) {
+                if ($filter === 'pagarme_split_order') {
+                    return [
+                        'sellers' => [
+                            [
+                                'marketplaceCommission' => 400,
+                                'commission'            => 800,
+                                'pagarmeId'             => "re_xxxxxxxxxxxxxxx"
+                            ]
+                        ],
+                        'marketplace' => [
+                            'totalCommission' => 400
+                        ]
+                    ];
+                }
+                return $value;
+            });
 
         $splitReturn = $platformOrderDecorator->handleSplitOrder();
         $this->assertInstanceOf(Split::class, $splitReturn);
@@ -107,19 +112,25 @@ class WoocommercePlatformOrderDecoratorTest extends TestCase
 
         $platformOrderDecorator = $this->returnBasicPlatformOrderDecorator();
 
-        Brain\Monkey\Filters\expectApplied('pagarme_split_order')
-            ->once()
-            ->andReturn([
-                'sellers' => [
-                    [
-                        'commission'            => 800,
-                        'pagarmeId'             => "re_xxxxxxxxxxxxxxx"
-                    ]
-                ],
-                'marketplace' => [
-                    'totalCommission' => 400
-                ]
-            ]);
+        // Mock do apply_filters para simular o filtro retornando dados inválidos
+        Brain\Monkey\Functions\when('apply_filters')
+            ->alias(function($filter, $value, ...$args) {
+                if ($filter === 'pagarme_split_order') {
+                    return [
+                        'sellers' => [
+                            [
+                                'commission'            => 800,
+                                'pagarmeId'             => "re_xxxxxxxxxxxxxxx"
+                                // Faltando 'marketplaceCommission' - isso deve causar InvalidArgumentException
+                            ]
+                        ],
+                        'marketplace' => [
+                            'totalCommission' => 400
+                        ]
+                    ];
+                }
+                return $value;
+            });
 
         $platformOrderDecorator->handleSplitOrder();
     }

--- a/tests/Model/ConfigTest.php
+++ b/tests/Model/ConfigTest.php
@@ -180,10 +180,7 @@ class ConfigTest extends TestCase
 
         $config->save($newConfig);
 
-        // Verifica que a nova configuração tem os dados corretos
         $this->assertEquals('test_value', $newConfig->getData('test_key'));
-
-        // As expectativas do Mockery (once()) serão verificadas automaticamente no tearDown
         $this->addToAssertionCount(1);
     }
 
@@ -241,24 +238,16 @@ class ConfigTest extends TestCase
         $configManagementMock = Mockery::mock(PagarmeCoreConfigManagement::class);
         $configManagementMock->shouldReceive('update')->never();
 
-        // Garantir que $_POST não contém a chave esperada
         $originalPost = $_POST;
         $_POST = [];
 
         $config = new Config($configManagementMock);
         $config->updateOption();
 
-        // Restaurar $_POST
         $_POST = $originalPost;
 
-        // As expectativas do Mockery (never()) serão verificadas automaticamente no tearDown
-        // Se update_option ou update fossem chamados, o teste falharia
         $this->addToAssertionCount(1);
     }
-
-    // ==========================================
-    // 3. TESTES DE DETECÇÃO DE SANDBOX MODE
-    // ==========================================
 
     public function testGetIsSandboxModeWithSandboxEnvironmentShouldReturnTrue()
     {
@@ -307,7 +296,6 @@ class ConfigTest extends TestCase
         $config = new Config();
         $config->setData('production_public_key', 'pk_test_abc123xyz');
         $config->setData('hub_environment', 'Production');
-        $config->setData('production_secret_key', 'sk_live_abc123xyz');
 
         $result = $config->getIsSandboxMode();
 
@@ -324,18 +312,14 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('production_secret_key', 'sk_live_abc123xyz');
-        $config->setData('production_public_key', 'pk_live_abc123xyz');
+        $config->setData('production_secret_key', 'sk_abc123xyz');
+        $config->setData('production_public_key', 'pk_abc123xyz');
         $config->setData('hub_environment', 'Production');
 
         $result = $config->getIsSandboxMode();
 
         $this->assertFalse($result);
     }
-
-    // ==========================================
-    // 4. TESTES DE HUB URLS
-    // ==========================================
 
     public function testGetHubUrlWithoutInstallIdShouldReturnIntegrateUrl()
     {
@@ -390,10 +374,6 @@ class ConfigTest extends TestCase
         $this->assertEquals('https://hub.pagar.me/apps/test_app_id/edit/install_123', $result);
     }
 
-    // ==========================================
-    // 5. TESTES DE DASH CONFIGURATION
-    // ==========================================
-
     public function testIsDashConfigAccessibleWithPaymentProfileIdShouldReturnTrue()
     {
         Brain\Monkey\Functions\stubs([
@@ -404,7 +384,7 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('payment_profile_id', 'profile_123');
+        $config->setData('payment_profile_id', 'pp_123');
 
         $result = $config->isDashConfigAccessible();
 
@@ -421,8 +401,8 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('merchant_id', 'merchant_123');
-        $config->setData('account_id', 'account_123');
+        $config->setData('merchant_id', 'merch_123');
+        $config->setData('account_id', 'acc_123');
 
         $result = $config->isDashConfigAccessible();
 
@@ -455,12 +435,12 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('merchant_id', 'merchant_123');
-        $config->setData('account_id', 'account_456');
+        $config->setData('merchant_id', 'merch_123');
+        $config->setData('account_id', 'acc_456');
 
         $result = $config->getDashUrl();
 
-        $this->assertEquals('https://dash.pagar.me/merchant_123/account_456/', $result);
+        $this->assertEquals('https://dash.pagar.me/merch_123/acc_456/', $result);
     }
 
     public function testGetDashUrlWithoutAccessShouldReturnNull()
@@ -479,10 +459,6 @@ class ConfigTest extends TestCase
         $this->assertNull($result);
     }
 
-    // ==========================================
-    // 6. TESTES DE KEYS (PUBLIC/SECRET)
-    // ==========================================
-
     public function testGetPublicKeyInProductionShouldReturnProductionKey()
     {
         Brain\Monkey\Functions\stubs([
@@ -493,13 +469,13 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('production_public_key', 'pk_live_production');
+        $config->setData('production_public_key', 'pk_production');
         $config->setData('sandbox_public_key', 'pk_test_sandbox');
         $config->setData('hub_environment', 'Production');
 
         $result = $config->getPublicKey();
 
-        $this->assertEquals('pk_live_production', $result);
+        $this->assertEquals('pk_production', $result);
     }
 
     public function testGetPublicKeyInSandboxShouldReturnSandboxKey()
@@ -512,7 +488,7 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('production_public_key', 'pk_live_production');
+        $config->setData('production_public_key', 'pk_production');
         $config->setData('sandbox_public_key', 'pk_test_sandbox');
         $config->setData('hub_environment', EnvironmentsTypes::SANDBOX_VALUE);
 
@@ -531,12 +507,12 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('production_public_key', 'pk_live_production');
+        $config->setData('production_public_key', 'pk_production');
         $config->setData('hub_environment', EnvironmentsTypes::SANDBOX_VALUE);
 
         $result = $config->getPublicKey();
 
-        $this->assertEquals('pk_live_production', $result);
+        $this->assertEquals('pk_production', $result);
     }
 
     public function testGetSecretKeyInProductionShouldReturnProductionKey()
@@ -549,13 +525,13 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('production_secret_key', 'sk_live_production');
+        $config->setData('production_secret_key', 'sk_production');
         $config->setData('sandbox_secret_key', 'sk_test_sandbox');
         $config->setData('hub_environment', 'Production');
 
         $result = $config->getSecretKey();
 
-        $this->assertEquals('sk_live_production', $result);
+        $this->assertEquals('sk_production', $result);
     }
 
     public function testGetSecretKeyInSandboxShouldReturnSandboxKey()
@@ -568,7 +544,7 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('production_secret_key', 'sk_live_production');
+        $config->setData('production_secret_key', 'sk_production');
         $config->setData('sandbox_secret_key', 'sk_test_sandbox');
         $config->setData('hub_environment', EnvironmentsTypes::SANDBOX_VALUE);
 
@@ -576,10 +552,6 @@ class ConfigTest extends TestCase
 
         $this->assertEquals('sk_test_sandbox', $result);
     }
-
-    // ==========================================
-    // 7. TESTES DE CARD OPERATIONS
-    // ==========================================
 
     public function testGetCardOperationForCoreWithOperationType2ShouldReturnAuthAndCapture()
     {
@@ -649,10 +621,6 @@ class ConfigTest extends TestCase
 
         $this->assertEquals([], $result);
     }
-
-    // ==========================================
-    // 8. TESTES DE PAYMENT METHODS ENABLED
-    // ==========================================
 
     public function testIsPixEnabledWithYesValueShouldReturnTrue()
     {
@@ -773,10 +741,6 @@ class ConfigTest extends TestCase
         $this->assertTrue($result);
     }
 
-    // ==========================================
-    // 9. TESTES DE COMPOSITE METHODS
-    // ==========================================
-
     public function testIsAnyBilletMethodEnabledWithBilletEnabledShouldReturnTrue()
     {
         Brain\Monkey\Functions\stubs([
@@ -880,11 +844,26 @@ class ConfigTest extends TestCase
         $this->assertTrue($result);
     }
 
-    // ==========================================
-    // 10. TESTES DE AVAILABLE PAYMENT METHODS
-    // ==========================================
+    public function testIsAnyCreditCardMethodEnabledWithAllDisabledShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
 
-    public function testAvailablePaymentMethodsShouldReturnCorrectArray()
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
+        $config = new Config();
+        $config->setData('enable_credit_card', 'no');
+        $config->setData('multimethods_2_cards', 'no');
+        $config->setData('multimethods_billet_card', 'no');
+
+        $result = $config->isAnyCreditCardMethodEnabled();
+
+        $this->assertFalse($result);
+    }
+
+    public function testAvailablePaymentMethodsShouldReturnCorrectArrayAndAllTrue()
     {
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
@@ -906,24 +885,6 @@ class ConfigTest extends TestCase
         $this->assertArrayHasKey(PaymentEnum::BILLET, $result);
         $this->assertArrayHasKey(PaymentEnum::CREDIT_CARD, $result);
         $this->assertArrayHasKey(PaymentEnum::VOUCHER, $result);
-    }
-
-    public function testAvailablePaymentMethodsWithAllEnabledShouldReturnAllTrue()
-    {
-        Brain\Monkey\Functions\stubs([
-            'get_option' => false,
-        ]);
-
-        $coreMock = Mockery::mock('alias:' . Core::class);
-        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
-
-        $config = new Config();
-        $config->setData('enable_pix', Config::ENABLED);
-        $config->setData('enable_billet', Config::ENABLED);
-        $config->setData('enable_credit_card', Config::ENABLED);
-        $config->setData('enable_voucher', Config::ENABLED);
-
-        $result = $config->availablePaymentMethods();
 
         $this->assertTrue($result[PaymentEnum::PIX]);
         $this->assertTrue($result[PaymentEnum::BILLET]);
@@ -954,10 +915,6 @@ class ConfigTest extends TestCase
         $this->assertFalse($result[PaymentEnum::VOUCHER]);
     }
 
-    // ==========================================
-    // 11. TESTES DE TDS (3D SECURE)
-    // ==========================================
-
     public function testIsTdsEnabledWithYesValueShouldReturnTrue()
     {
         Brain\Monkey\Functions\stubs([
@@ -973,6 +930,23 @@ class ConfigTest extends TestCase
         $result = $config->isTdsEnabled();
 
         $this->assertTrue($result);
+    }
+
+    public function testIsTdsEnabledWithNoValueShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
+        $config = new Config();
+        $config->setData('tds_enabled', 'no');
+
+        $result = $config->isTdsEnabled();
+
+        $this->assertFalse($result);
     }
 
     public function testGetTdsMinAmountWithEmptyValueShouldReturnZero()
@@ -1051,14 +1025,10 @@ class ConfigTest extends TestCase
         $this->assertEquals(1234.56, $result);
     }
 
-    // ==========================================
-    // 12. TESTES DE SETTERS E GETTERS ESPECÍFICOS
-    // ==========================================
-
     public function testSetAccountIdShouldSetDataAndUpdateGooglepay()
     {
         Brain\Monkey\Functions\stubs([
-            'get_option' => ['account_id' => 'old_account'],
+            'get_option' => ['account_id' => 'acc_old'],
         ]);
 
         $coreMock = Mockery::mock('alias:' . Core::class);
@@ -1104,9 +1074,9 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setPaymentProfileId('profile_123');
+        $config->setPaymentProfileId('pp_123');
 
-        $this->assertEquals('profile_123', $config->getData('payment_profile_id'));
+        $this->assertEquals('pp_123', $config->getData('payment_profile_id'));
     }
 
     public function testSetPoiTypeShouldSetDataCorrectly()
@@ -1119,9 +1089,9 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setPoiType('type_123');
+        $config->setPoiType('ecommerce');
 
-        $this->assertEquals('type_123', $config->getData('poi_type'));
+        $this->assertEquals('ecommerce', $config->getData('poi_type'));
     }
 
     public function testGetPaymentProfileIdShouldReturnStoredValue()
@@ -1134,11 +1104,11 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('payment_profile_id', 'profile_456');
+        $config->setData('payment_profile_id', 'pp_456');
 
         $result = $config->getPaymentProfileId();
 
-        $this->assertEquals('profile_456', $result);
+        $this->assertEquals('pp_456', $result);
     }
 
     public function testGetPoiTypeShouldReturnStoredValue()
@@ -1151,16 +1121,12 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('poi_type', 'type_456');
+        $config->setData('poi_type', 'ecommerce');
 
         $result = $config->getPoiType();
 
-        $this->assertEquals('type_456', $result);
+        $this->assertEquals('ecommerce', $result);
     }
-
-    // ==========================================
-    // 13. TESTES DE ONESTONE
-    // ==========================================
 
     public function testIsOneStoneEnabledWithPaymentProfileIdShouldReturnTrue()
     {
@@ -1172,7 +1138,7 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('payment_profile_id', 'profile_123');
+        $config->setData('payment_profile_id', 'pp_123');
 
         $result = $config->isOneStoneEnabled();
 
@@ -1194,10 +1160,6 @@ class ConfigTest extends TestCase
 
         $this->assertFalse($result);
     }
-
-    // ==========================================
-    // 14. TESTES DE INSTALLMENTS
-    // ==========================================
 
     public function testGetIsInstallmentsDefaultConfigWithLegacyTypeShouldReturnTrue()
     {
@@ -1266,10 +1228,6 @@ class ConfigTest extends TestCase
 
         $this->assertEquals(CardInstallments::INSTALLMENTS_BY_FLAG, $result);
     }
-
-    // ==========================================
-    // 15. TESTES DE FEATURE FLAGS AUXILIARES
-    // ==========================================
 
     public function testGetMulticustomersShouldCheckMulticustomersFlag()
     {
@@ -1407,10 +1365,6 @@ class ConfigTest extends TestCase
         $this->assertTrue($result);
     }
 
-    // ==========================================
-    // 16. TESTES DE VOUCHER PSP
-    // ==========================================
-
     public function testGetIsVoucherPSPWithVoucherTrueShouldReturnTrue()
     {
         Brain\Monkey\Functions\stubs([
@@ -1462,10 +1416,6 @@ class ConfigTest extends TestCase
         $this->assertFalse($result);
     }
 
-    // ==========================================
-    // 17. TESTES DE LOGGER
-    // ==========================================
-
     public function testLogShouldReturnWCLoggerInstance()
     {
         Brain\Monkey\Functions\stubs([
@@ -1481,10 +1431,6 @@ class ConfigTest extends TestCase
 
         $this->assertInstanceOf(WC_Logger::class, $result);
     }
-
-    // ==========================================
-    // 18. TESTES DE OPTION KEY
-    // ==========================================
 
     public function testGetOptionKeyShouldReturnPrefixedSettingsKey()
     {

--- a/tests/Model/ConfigTest.php
+++ b/tests/Model/ConfigTest.php
@@ -374,7 +374,7 @@ class ConfigTest extends TestCase
         $this->assertEquals('https://hub.pagar.me/apps/test_app_id/edit/install_123', $result);
     }
 
-    public function testIsDashConfigAccessibleWithPaymentProfileIdShouldReturnTrue()
+    public function testIsDashConfigAccessibleWithPaymentProfileIdShouldReturnFalse()
     {
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
@@ -386,9 +386,9 @@ class ConfigTest extends TestCase
         $config = new Config();
         $config->setData('payment_profile_id', 'pp_123');
 
-        $result = $config->isDashConfigAccessible();
+        $result = $config->isPagarmeDashConfigAccessible();
 
-        $this->assertTrue($result);
+        $this->assertFalse($result);
     }
 
     public function testIsDashConfigAccessibleWithMerchantAndAccountIdShouldReturnTrue()
@@ -404,7 +404,7 @@ class ConfigTest extends TestCase
         $config->setData('merchant_id', 'merch_123');
         $config->setData('account_id', 'acc_123');
 
-        $result = $config->isDashConfigAccessible();
+        $result = $config->isPagarmeDashConfigAccessible();
 
         $this->assertTrue($result);
     }
@@ -420,7 +420,7 @@ class ConfigTest extends TestCase
 
         $config = new Config();
 
-        $result = $config->isDashConfigAccessible();
+        $result = $config->isPagarmeDashConfigAccessible();
 
         $this->assertFalse($result);
     }
@@ -438,7 +438,7 @@ class ConfigTest extends TestCase
         $config->setData('merchant_id', 'merch_123');
         $config->setData('account_id', 'acc_456');
 
-        $result = $config->getDashUrl();
+        $result = $config->getPagarmeDashUrl();
 
         $this->assertEquals('https://dash.pagar.me/merch_123/acc_456/', $result);
     }
@@ -454,7 +454,7 @@ class ConfigTest extends TestCase
 
         $config = new Config();
 
-        $result = $config->getDashUrl();
+        $result = $config->getPagarmeDashUrl();
 
         $this->assertNull($result);
     }

--- a/tests/Model/ConfigTest.php
+++ b/tests/Model/ConfigTest.php
@@ -36,11 +36,6 @@ class ConfigTest extends TestCase
         Mockery::close();
         Brain\Monkey\tearDown();
     }
-
-    // ==========================================
-    // 1. TESTES DE CONSTRUTOR E INICIALIZAÇÃO
-    // ==========================================
-
     public function testConstructorWithDefaultParametersShouldInitializeCorrectly()
     {
         Brain\Monkey\Functions\stubs([
@@ -125,11 +120,6 @@ class ConfigTest extends TestCase
 
         $this->assertEmpty($config->getData());
     }
-
-    // ==========================================
-    // 2. TESTES DE SAVE E UPDATE
-    // ==========================================
-
     public function testSaveWithoutParameterShouldSaveCurrentInstance()
     {
         Brain\Monkey\Functions\stubs([
@@ -143,16 +133,20 @@ class ConfigTest extends TestCase
 
         Brain\Monkey\Functions\expect('update_option')
             ->once()
-            ->with('pagarme_settings', Mockery::any());
+            ->with('pagarme_settings', Mockery::any())
+            ->andReturn(true);
 
         $configManagementMock = Mockery::mock(PagarmeCoreConfigManagement::class);
         $configManagementMock->shouldReceive('update')
-            ->once();
+            ->once()
+            ->with(Mockery::type(Config::class));
 
         $config = new Config($configManagementMock);
+        $config->setData('test_key', 'test_value');
         $config->save();
 
-        $this->assertTrue(true);
+        $this->assertEquals('test_value', $config->getData('test_key'));
+        $this->addToAssertionCount(1);
     }
 
     public function testSaveWithConfigParameterShouldSaveProvidedConfig()
@@ -170,18 +164,27 @@ class ConfigTest extends TestCase
 
         Brain\Monkey\Functions\expect('update_option')
             ->once()
-            ->with('pagarme_settings', $newConfigData);
+            ->with('pagarme_settings', $newConfigData)
+            ->andReturn(true);
 
         $configManagementMock = Mockery::mock(PagarmeCoreConfigManagement::class);
         $configManagementMock->shouldReceive('update')
-            ->once();
+            ->once()
+            ->with(Mockery::on(function ($arg) use ($newConfigData) {
+                return $arg instanceof Config
+                    && $arg->getData('test_key') === $newConfigData['test_key'];
+            }));
 
         $config = new Config($configManagementMock);
         $newConfig = new Config(null, null, $newConfigData);
 
         $config->save($newConfig);
 
-        $this->assertTrue(true);
+        // Verifica que a nova configuração tem os dados corretos
+        $this->assertEquals('test_value', $newConfig->getData('test_key'));
+
+        // As expectativas do Mockery (once()) serão verificadas automaticamente no tearDown
+        $this->addToAssertionCount(1);
     }
 
     public function testUpdateOptionWithValidPostDataShouldUpdateConfiguration()
@@ -238,10 +241,19 @@ class ConfigTest extends TestCase
         $configManagementMock = Mockery::mock(PagarmeCoreConfigManagement::class);
         $configManagementMock->shouldReceive('update')->never();
 
+        // Garantir que $_POST não contém a chave esperada
+        $originalPost = $_POST;
+        $_POST = [];
+
         $config = new Config($configManagementMock);
         $config->updateOption();
 
-        $this->assertTrue(true);
+        // Restaurar $_POST
+        $_POST = $originalPost;
+
+        // As expectativas do Mockery (never()) serão verificadas automaticamente no tearDown
+        // Se update_option ou update fossem chamados, o teste falharia
+        $this->addToAssertionCount(1);
     }
 
     // ==========================================

--- a/tests/Model/ConfigTest.php
+++ b/tests/Model/ConfigTest.php
@@ -47,6 +47,10 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')
+            ->andReturn('pagarme_settings');
+
         $config = new Config();
 
         $reflectionClass = new ReflectionClass($config);
@@ -62,6 +66,10 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')
+            ->andReturn('pagarme_settings');
 
         $data = [
             'test_key' => 'test_value',
@@ -82,7 +90,7 @@ class ConfigTest extends TestCase
         ];
 
         Brain\Monkey\Functions\expect('get_option')
-            ->once()
+            ->atLeast()->once()
             ->andReturn($optionData);
 
         Brain\Monkey\Functions\expect('add_action')
@@ -102,7 +110,7 @@ class ConfigTest extends TestCase
     public function testInitWithNoOptionsShouldNotLoadData()
     {
         Brain\Monkey\Functions\expect('get_option')
-            ->once()
+            ->atLeast()->once()
             ->andReturn(false);
 
         Brain\Monkey\Functions\expect('add_action')
@@ -246,6 +254,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('hub_environment', Config::HUB_SANDBOX_ENVIRONMENT);
 
@@ -259,6 +270,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('production_secret_key', 'sk_test_abc123xyz');
@@ -275,6 +289,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('production_public_key', 'pk_test_abc123xyz');
         $config->setData('hub_environment', 'Production');
@@ -290,6 +307,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('production_secret_key', 'sk_live_abc123xyz');
@@ -316,6 +336,7 @@ class ConfigTest extends TestCase
             ->andReturn('test_app_id');
 
         $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
         $coreMock->shouldReceive('getHubUrl')
             ->andReturn('https://test.site/hub');
 
@@ -342,6 +363,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $coreSetupMock = Mockery::mock('alias:' . CoreSetup::class);
         $coreSetupMock->shouldReceive('getHubAppPublicAppKey')
             ->andReturn('test_app_id');
@@ -364,6 +388,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('payment_profile_id', 'profile_123');
 
@@ -377,6 +404,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('merchant_id', 'merchant_123');
@@ -393,6 +423,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
 
         $result = $config->isDashConfigAccessible();
@@ -405,6 +438,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('merchant_id', 'merchant_123');
@@ -420,6 +456,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
 
@@ -438,6 +477,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('production_public_key', 'pk_live_production');
         $config->setData('sandbox_public_key', 'pk_test_sandbox');
@@ -453,6 +495,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('production_public_key', 'pk_live_production');
@@ -470,6 +515,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('production_public_key', 'pk_live_production');
         $config->setData('hub_environment', EnvironmentsTypes::SANDBOX_VALUE);
@@ -484,6 +532,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('production_secret_key', 'sk_live_production');
@@ -500,6 +551,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('production_secret_key', 'sk_live_production');
@@ -521,6 +575,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('cc_operation_type', 2);
 
@@ -535,6 +592,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('cc_operation_type', 1);
 
@@ -548,6 +608,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $flags = ['visa', 'mastercard', 'elo'];
 
@@ -564,6 +627,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
 
@@ -582,6 +648,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('enable_pix', Config::ENABLED);
 
@@ -595,6 +664,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('enable_pix', 'no');
@@ -610,6 +682,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('enable_billet', Config::ENABLED);
 
@@ -623,6 +698,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('enable_credit_card', Config::ENABLED);
@@ -638,6 +716,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('enable_voucher', Config::ENABLED);
 
@@ -652,6 +733,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('multimethods_2_cards', Config::ENABLED);
 
@@ -665,6 +749,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('multimethods_billet_card', Config::ENABLED);
@@ -684,6 +771,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('enable_billet', Config::ENABLED);
 
@@ -698,6 +788,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('multimethods_billet_card', Config::ENABLED);
 
@@ -711,6 +804,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('enable_billet', 'no');
@@ -727,6 +823,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('enable_credit_card', Config::ENABLED);
 
@@ -741,6 +840,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('multimethods_2_cards', Config::ENABLED);
 
@@ -754,6 +856,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('multimethods_billet_card', Config::ENABLED);
@@ -772,6 +877,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('enable_pix', Config::ENABLED);
@@ -794,6 +902,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('enable_pix', Config::ENABLED);
         $config->setData('enable_billet', Config::ENABLED);
@@ -813,6 +924,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('enable_pix', 'no');
@@ -838,6 +952,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('tds_enabled', Config::ENABLED);
 
@@ -851,6 +968,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('tds_min_amount', '');
@@ -866,6 +986,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('tds_min_amount', '100');
 
@@ -880,6 +1003,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('tds_min_amount', 150);
 
@@ -893,6 +1019,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $moneyServiceMock = Mockery::mock('overload:' . MoneyService::class);
         $moneyServiceMock->shouldReceive('removeSeparators')
@@ -920,6 +1049,9 @@ class ConfigTest extends TestCase
             'get_option' => ['account_id' => 'old_account'],
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         Brain\Monkey\Functions\expect('update_option')
             ->once()
             ->with('woocommerce_woo-pagarme-payments-googlepay_settings', Mockery::on(function ($arg) {
@@ -934,8 +1066,11 @@ class ConfigTest extends TestCase
 
     public function testSetAccountIdWithoutGooglepayOptionShouldOnlySetData()
     {
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         Brain\Monkey\Functions\expect('get_option')
-            ->twice()
+            ->atLeast()->once()
             ->andReturn(false);
 
         Brain\Monkey\Functions\expect('update_option')
@@ -953,6 +1088,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setPaymentProfileId('profile_123');
 
@@ -965,6 +1103,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setPoiType('type_123');
 
@@ -976,6 +1117,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('payment_profile_id', 'profile_456');
@@ -990,6 +1134,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('poi_type', 'type_456');
@@ -1009,6 +1156,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('payment_profile_id', 'profile_123');
 
@@ -1022,6 +1172,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
 
@@ -1040,6 +1193,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('cc_installment_type', CardInstallments::INSTALLMENTS_LEGACY);
 
@@ -1053,6 +1209,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('cc_installment_type', CardInstallments::INSTALLMENTS_FOR_ALL_FLAGS);
@@ -1068,6 +1227,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('cc_installment_type', CardInstallments::INSTALLMENTS_BY_FLAG);
 
@@ -1081,6 +1243,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('cc_installment_type', CardInstallments::INSTALLMENTS_BY_FLAG);
@@ -1100,6 +1265,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('multicustomers', Config::ENABLED);
 
@@ -1113,6 +1281,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('modify_address', Config::ENABLED);
@@ -1128,6 +1299,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('allow_no_address', Config::ENABLED);
 
@@ -1141,6 +1315,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('cc_allow_save', Config::ENABLED);
@@ -1156,6 +1333,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('voucher_card_wallet', Config::ENABLED);
 
@@ -1169,6 +1349,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('enable_logs', Config::ENABLED);
@@ -1184,6 +1367,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('is_gateway_integration_type', Config::ENABLED);
 
@@ -1197,6 +1383,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('antifraud_enabled', Config::ENABLED);
@@ -1216,6 +1405,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('is_payment_psp', ['voucher' => true]);
 
@@ -1230,6 +1422,9 @@ class ConfigTest extends TestCase
             'get_option' => false,
         ]);
 
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
+
         $config = new Config();
         $config->setData('is_payment_psp', ['voucher' => false]);
 
@@ -1243,6 +1438,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
         $config->setData('is_payment_psp', ['credit_card' => true]);
@@ -1261,6 +1459,9 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\stubs([
             'get_option' => false,
         ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
 

--- a/tests/Model/ConfigTest.php
+++ b/tests/Model/ConfigTest.php
@@ -1,0 +1,1293 @@
+<?php
+
+namespace Woocommerce\Pagarme\Tests\Model;
+
+use Brain;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Pagarme\Core\Hub\Services\HubIntegrationService;
+use Pagarme\Core\Kernel\Services\MoneyService;
+use Pagarme\Core\Kernel\ValueObjects\Id\InstallId;
+use Pagarme\Core\Middle\Model\Account\PaymentEnum;
+use WC_Logger;
+use Woocommerce\Pagarme\Concrete\WoocommerceCoreSetup as CoreSetup;
+use Woocommerce\Pagarme\Core;
+use Woocommerce\Pagarme\Model\CardInstallments;
+use Woocommerce\Pagarme\Model\Config;
+use Woocommerce\Pagarme\Model\Config\PagarmeCoreConfigManagement;
+use Woocommerce\Pagarme\Model\Config\Source\EnvironmentsTypes;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class ConfigTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        Brain\Monkey\setUp();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+        Brain\Monkey\tearDown();
+    }
+
+    // ==========================================
+    // 1. TESTES DE CONSTRUTOR E INICIALIZAÇÃO
+    // ==========================================
+
+    public function testConstructorWithDefaultParametersShouldInitializeCorrectly()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+
+        $reflectionClass = new ReflectionClass($config);
+        $property = $reflectionClass->getProperty('pagarmeCoreConfigManagement');
+        $property->setAccessible(true);
+        $value = $property->getValue($config);
+
+        $this->assertInstanceOf(PagarmeCoreConfigManagement::class, $value);
+    }
+
+    public function testConstructorWithDataArrayShouldSetDataCorrectly()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $data = [
+            'test_key' => 'test_value',
+            'another_key' => 'another_value'
+        ];
+
+        $config = new Config(null, null, $data);
+
+        $this->assertEquals('test_value', $config->getData('test_key'));
+        $this->assertEquals('another_value', $config->getData('another_key'));
+    }
+
+    public function testInitWithValidOptionsShouldLoadDataFromWordPress()
+    {
+        $optionData = [
+            'enable_pix' => 'yes',
+            'enable_billet' => 'no',
+        ];
+
+        Brain\Monkey\Functions\expect('get_option')
+            ->once()
+            ->andReturn($optionData);
+
+        Brain\Monkey\Functions\expect('add_action')
+            ->once();
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')
+            ->with('settings')
+            ->andReturn('pagarme_settings');
+
+        $config = new Config();
+
+        $this->assertEquals('yes', $config->getData('enable_pix'));
+        $this->assertEquals('no', $config->getData('enable_billet'));
+    }
+
+    public function testInitWithNoOptionsShouldNotLoadData()
+    {
+        Brain\Monkey\Functions\expect('get_option')
+            ->once()
+            ->andReturn(false);
+
+        Brain\Monkey\Functions\expect('add_action')
+            ->never();
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')
+            ->with('settings')
+            ->andReturn('pagarme_settings');
+
+        $config = new Config();
+
+        $this->assertEmpty($config->getData());
+    }
+
+    // ==========================================
+    // 2. TESTES DE SAVE E UPDATE
+    // ==========================================
+
+    public function testSaveWithoutParameterShouldSaveCurrentInstance()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')
+            ->with('settings')
+            ->andReturn('pagarme_settings');
+
+        Brain\Monkey\Functions\expect('update_option')
+            ->once()
+            ->with('pagarme_settings', Mockery::any());
+
+        $configManagementMock = Mockery::mock(PagarmeCoreConfigManagement::class);
+        $configManagementMock->shouldReceive('update')
+            ->once();
+
+        $config = new Config($configManagementMock);
+        $config->save();
+
+        $this->assertTrue(true);
+    }
+
+    public function testSaveWithConfigParameterShouldSaveProvidedConfig()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')
+            ->with('settings')
+            ->andReturn('pagarme_settings');
+
+        $newConfigData = ['test_key' => 'test_value'];
+
+        Brain\Monkey\Functions\expect('update_option')
+            ->once()
+            ->with('pagarme_settings', $newConfigData);
+
+        $configManagementMock = Mockery::mock(PagarmeCoreConfigManagement::class);
+        $configManagementMock->shouldReceive('update')
+            ->once();
+
+        $config = new Config($configManagementMock);
+        $newConfig = new Config(null, null, $newConfigData);
+
+        $config->save($newConfig);
+
+        $this->assertTrue(true);
+    }
+
+    public function testUpdateOptionWithValidPostDataShouldUpdateConfiguration()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')
+            ->with('settings')
+            ->andReturn('pagarme_settings');
+
+        $_POST['pagarme_settings'] = [
+            'enable_pix' => 'yes',
+            'enable_billet' => 'no'
+        ];
+
+        Brain\Monkey\Functions\expect('sanitize_text_field')
+            ->twice()
+            ->andReturnUsing(function ($value) {
+                return $value;
+            });
+
+        Brain\Monkey\Functions\expect('update_option')
+            ->once();
+
+        $configManagementMock = Mockery::mock(PagarmeCoreConfigManagement::class);
+        $configManagementMock->shouldReceive('update')->once();
+
+        $config = new Config($configManagementMock);
+        $config->updateOption();
+
+        $this->assertEquals('yes', $config->getData('enable_pix'));
+        $this->assertEquals('no', $config->getData('enable_billet'));
+
+        unset($_POST['pagarme_settings']);
+    }
+
+    public function testUpdateOptionWithoutPostDataShouldNotUpdate()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')
+            ->with('settings')
+            ->andReturn('pagarme_settings');
+
+        Brain\Monkey\Functions\expect('update_option')
+            ->never();
+
+        $configManagementMock = Mockery::mock(PagarmeCoreConfigManagement::class);
+        $configManagementMock->shouldReceive('update')->never();
+
+        $config = new Config($configManagementMock);
+        $config->updateOption();
+
+        $this->assertTrue(true);
+    }
+
+    // ==========================================
+    // 3. TESTES DE DETECÇÃO DE SANDBOX MODE
+    // ==========================================
+
+    public function testGetIsSandboxModeWithSandboxEnvironmentShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('hub_environment', Config::HUB_SANDBOX_ENVIRONMENT);
+
+        $result = $config->getIsSandboxMode();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetIsSandboxModeWithTestSecretKeyShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('production_secret_key', 'sk_test_abc123xyz');
+        $config->setData('hub_environment', 'Production');
+
+        $result = $config->getIsSandboxMode();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetIsSandboxModeWithTestPublicKeyShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('production_public_key', 'pk_test_abc123xyz');
+        $config->setData('hub_environment', 'Production');
+        $config->setData('production_secret_key', 'sk_live_abc123xyz');
+
+        $result = $config->getIsSandboxMode();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetIsSandboxModeWithProductionKeysShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('production_secret_key', 'sk_live_abc123xyz');
+        $config->setData('production_public_key', 'pk_live_abc123xyz');
+        $config->setData('hub_environment', 'Production');
+
+        $result = $config->getIsSandboxMode();
+
+        $this->assertFalse($result);
+    }
+
+    // ==========================================
+    // 4. TESTES DE HUB URLS
+    // ==========================================
+
+    public function testGetHubUrlWithoutInstallIdShouldReturnIntegrateUrl()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $coreSetupMock = Mockery::mock('alias:' . CoreSetup::class);
+        $coreSetupMock->shouldReceive('getHubAppPublicAppKey')
+            ->andReturn('test_app_id');
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('getHubUrl')
+            ->andReturn('https://test.site/hub');
+
+        $installIdMock = Mockery::mock(InstallId::class);
+        $installIdMock->shouldReceive('getValue')
+            ->andReturn('install_token_123');
+
+        $hubServiceMock = Mockery::mock('overload:' . HubIntegrationService::class);
+        $hubServiceMock->shouldReceive('startHubIntegration')
+            ->andReturn($installIdMock);
+
+        $config = new Config();
+        $config->setData('hub_install_id', null);
+
+        $result = $config->getHubUrl();
+
+        $this->assertStringContainsString('https://hub.pagar.me/apps/test_app_id/authorize', $result);
+        $this->assertStringContainsString('install_token=install_token_123', $result);
+    }
+
+    public function testGetHubUrlWithInstallIdShouldReturnViewIntegrationUrl()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $coreSetupMock = Mockery::mock('alias:' . CoreSetup::class);
+        $coreSetupMock->shouldReceive('getHubAppPublicAppKey')
+            ->andReturn('test_app_id');
+
+        $config = new Config();
+        $config->setData('hub_install_id', 'install_123');
+
+        $result = $config->getHubUrl();
+
+        $this->assertEquals('https://hub.pagar.me/apps/test_app_id/edit/install_123', $result);
+    }
+
+    // ==========================================
+    // 5. TESTES DE DASH CONFIGURATION
+    // ==========================================
+
+    public function testIsDashConfigAccessibleWithPaymentProfileIdShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('payment_profile_id', 'profile_123');
+
+        $result = $config->isDashConfigAccessible();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsDashConfigAccessibleWithMerchantAndAccountIdShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('merchant_id', 'merchant_123');
+        $config->setData('account_id', 'account_123');
+
+        $result = $config->isDashConfigAccessible();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsDashConfigAccessibleWithoutRequiredDataShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+
+        $result = $config->isDashConfigAccessible();
+
+        $this->assertFalse($result);
+    }
+
+    public function testGetDashUrlWithValidConfigShouldReturnFormattedUrl()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('merchant_id', 'merchant_123');
+        $config->setData('account_id', 'account_456');
+
+        $result = $config->getDashUrl();
+
+        $this->assertEquals('https://dash.pagar.me/merchant_123/account_456/', $result);
+    }
+
+    public function testGetDashUrlWithoutAccessShouldReturnNull()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+
+        $result = $config->getDashUrl();
+
+        $this->assertNull($result);
+    }
+
+    // ==========================================
+    // 6. TESTES DE KEYS (PUBLIC/SECRET)
+    // ==========================================
+
+    public function testGetPublicKeyInProductionShouldReturnProductionKey()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('production_public_key', 'pk_live_production');
+        $config->setData('sandbox_public_key', 'pk_test_sandbox');
+        $config->setData('hub_environment', 'Production');
+
+        $result = $config->getPublicKey();
+
+        $this->assertEquals('pk_live_production', $result);
+    }
+
+    public function testGetPublicKeyInSandboxShouldReturnSandboxKey()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('production_public_key', 'pk_live_production');
+        $config->setData('sandbox_public_key', 'pk_test_sandbox');
+        $config->setData('hub_environment', EnvironmentsTypes::SANDBOX_VALUE);
+
+        $result = $config->getPublicKey();
+
+        $this->assertEquals('pk_test_sandbox', $result);
+    }
+
+    public function testGetPublicKeyInSandboxWithoutSandboxKeyShouldReturnProductionKey()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('production_public_key', 'pk_live_production');
+        $config->setData('hub_environment', EnvironmentsTypes::SANDBOX_VALUE);
+
+        $result = $config->getPublicKey();
+
+        $this->assertEquals('pk_live_production', $result);
+    }
+
+    public function testGetSecretKeyInProductionShouldReturnProductionKey()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('production_secret_key', 'sk_live_production');
+        $config->setData('sandbox_secret_key', 'sk_test_sandbox');
+        $config->setData('hub_environment', 'Production');
+
+        $result = $config->getSecretKey();
+
+        $this->assertEquals('sk_live_production', $result);
+    }
+
+    public function testGetSecretKeyInSandboxShouldReturnSandboxKey()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('production_secret_key', 'sk_live_production');
+        $config->setData('sandbox_secret_key', 'sk_test_sandbox');
+        $config->setData('hub_environment', EnvironmentsTypes::SANDBOX_VALUE);
+
+        $result = $config->getSecretKey();
+
+        $this->assertEquals('sk_test_sandbox', $result);
+    }
+
+    // ==========================================
+    // 7. TESTES DE CARD OPERATIONS
+    // ==========================================
+
+    public function testGetCardOperationForCoreWithOperationType2ShouldReturnAuthAndCapture()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('cc_operation_type', 2);
+
+        $result = $config->getCardOperationForCore();
+
+        $this->assertEquals('auth_and_capture', $result);
+    }
+
+    public function testGetCardOperationForCoreWithOperationType1ShouldReturnAuthOnly()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('cc_operation_type', 1);
+
+        $result = $config->getCardOperationForCore();
+
+        $this->assertEquals('auth_only', $result);
+    }
+
+    public function testGetCcFlagsWithDataShouldReturnArray()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $flags = ['visa', 'mastercard', 'elo'];
+
+        $config = new Config();
+        $config->setData('cc_flags', $flags);
+
+        $result = $config->getCcFlags();
+
+        $this->assertEquals($flags, $result);
+    }
+
+    public function testGetCcFlagsWithoutDataShouldReturnEmptyArray()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+
+        $result = $config->getCcFlags();
+
+        $this->assertEquals([], $result);
+    }
+
+    // ==========================================
+    // 8. TESTES DE PAYMENT METHODS ENABLED
+    // ==========================================
+
+    public function testIsPixEnabledWithYesValueShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_pix', Config::ENABLED);
+
+        $result = $config->isPixEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsPixEnabledWithNoValueShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_pix', 'no');
+
+        $result = $config->isPixEnabled();
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsBilletEnabledWithYesValueShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_billet', Config::ENABLED);
+
+        $result = $config->isBilletEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsCreditCardEnabledWithYesValueShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_credit_card', Config::ENABLED);
+
+        $result = $config->isCreditCardEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsVoucherEnabledWithYesValueShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_voucher', Config::ENABLED);
+
+        $result = $config->isVoucherEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsTwoCreditCardEnabledWithYesValueShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('multimethods_2_cards', Config::ENABLED);
+
+        $result = $config->isTwoCreditCardEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsBilletAndCreditCardEnabledWithYesValueShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('multimethods_billet_card', Config::ENABLED);
+
+        $result = $config->isBilletAndCreditCardEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    // ==========================================
+    // 9. TESTES DE COMPOSITE METHODS
+    // ==========================================
+
+    public function testIsAnyBilletMethodEnabledWithBilletEnabledShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_billet', Config::ENABLED);
+
+        $result = $config->isAnyBilletMethodEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsAnyBilletMethodEnabledWithBilletAndCardEnabledShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('multimethods_billet_card', Config::ENABLED);
+
+        $result = $config->isAnyBilletMethodEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsAnyBilletMethodEnabledWithAllDisabledShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_billet', 'no');
+        $config->setData('multimethods_billet_card', 'no');
+
+        $result = $config->isAnyBilletMethodEnabled();
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsAnyCreditCardMethodEnabledWithCreditCardEnabledShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_credit_card', Config::ENABLED);
+
+        $result = $config->isAnyCreditCardMethodEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsAnyCreditCardMethodEnabledWithTwoCardsEnabledShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('multimethods_2_cards', Config::ENABLED);
+
+        $result = $config->isAnyCreditCardMethodEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsAnyCreditCardMethodEnabledWithBilletAndCardEnabledShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('multimethods_billet_card', Config::ENABLED);
+
+        $result = $config->isAnyCreditCardMethodEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    // ==========================================
+    // 10. TESTES DE AVAILABLE PAYMENT METHODS
+    // ==========================================
+
+    public function testAvailablePaymentMethodsShouldReturnCorrectArray()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_pix', Config::ENABLED);
+        $config->setData('enable_billet', Config::ENABLED);
+        $config->setData('enable_credit_card', Config::ENABLED);
+        $config->setData('enable_voucher', Config::ENABLED);
+
+        $result = $config->availablePaymentMethods();
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey(PaymentEnum::PIX, $result);
+        $this->assertArrayHasKey(PaymentEnum::BILLET, $result);
+        $this->assertArrayHasKey(PaymentEnum::CREDIT_CARD, $result);
+        $this->assertArrayHasKey(PaymentEnum::VOUCHER, $result);
+    }
+
+    public function testAvailablePaymentMethodsWithAllEnabledShouldReturnAllTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_pix', Config::ENABLED);
+        $config->setData('enable_billet', Config::ENABLED);
+        $config->setData('enable_credit_card', Config::ENABLED);
+        $config->setData('enable_voucher', Config::ENABLED);
+
+        $result = $config->availablePaymentMethods();
+
+        $this->assertTrue($result[PaymentEnum::PIX]);
+        $this->assertTrue($result[PaymentEnum::BILLET]);
+        $this->assertTrue($result[PaymentEnum::CREDIT_CARD]);
+        $this->assertTrue($result[PaymentEnum::VOUCHER]);
+    }
+
+    public function testAvailablePaymentMethodsWithAllDisabledShouldReturnAllFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_pix', 'no');
+        $config->setData('enable_billet', 'no');
+        $config->setData('enable_credit_card', 'no');
+        $config->setData('enable_voucher', 'no');
+
+        $result = $config->availablePaymentMethods();
+
+        $this->assertFalse($result[PaymentEnum::PIX]);
+        $this->assertFalse($result[PaymentEnum::BILLET]);
+        $this->assertFalse($result[PaymentEnum::CREDIT_CARD]);
+        $this->assertFalse($result[PaymentEnum::VOUCHER]);
+    }
+
+    // ==========================================
+    // 11. TESTES DE TDS (3D SECURE)
+    // ==========================================
+
+    public function testIsTdsEnabledWithYesValueShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('tds_enabled', Config::ENABLED);
+
+        $result = $config->isTdsEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetTdsMinAmountWithEmptyValueShouldReturnZero()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('tds_min_amount', '');
+
+        $result = $config->getTdsMinAmount();
+
+        $this->assertEquals(0, $result);
+    }
+
+    public function testGetTdsMinAmountWithNumericStringShouldReturnInteger()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('tds_min_amount', '100');
+
+        $result = $config->getTdsMinAmount();
+
+        $this->assertEquals(100, $result);
+    }
+
+    public function testGetTdsMinAmountWithIntegerShouldReturnInteger()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('tds_min_amount', 150);
+
+        $result = $config->getTdsMinAmount();
+
+        $this->assertEquals(150, $result);
+    }
+
+    public function testGetTdsMinAmountWithFormattedStringShouldConvertCorrectly()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $moneyServiceMock = Mockery::mock('overload:' . MoneyService::class);
+        $moneyServiceMock->shouldReceive('removeSeparators')
+            ->with('1.234,56')
+            ->andReturn('123456');
+        $moneyServiceMock->shouldReceive('centsToFloat')
+            ->with('123456')
+            ->andReturn(1234.56);
+
+        $config = new Config();
+        $config->setData('tds_min_amount', '1.234,56');
+
+        $result = $config->getTdsMinAmount();
+
+        $this->assertEquals(1234.56, $result);
+    }
+
+    // ==========================================
+    // 12. TESTES DE SETTERS E GETTERS ESPECÍFICOS
+    // ==========================================
+
+    public function testSetAccountIdShouldSetDataAndUpdateGooglepay()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => ['account_id' => 'old_account'],
+        ]);
+
+        Brain\Monkey\Functions\expect('update_option')
+            ->once()
+            ->with('woocommerce_woo-pagarme-payments-googlepay_settings', Mockery::on(function ($arg) {
+                return is_array($arg) && $arg['account_id'] === 'acc_123';
+            }));
+
+        $config = new Config();
+        $config->setAccountId('acc_123');
+
+        $this->assertEquals('acc_123', $config->getData('account_id'));
+    }
+
+    public function testSetAccountIdWithoutGooglepayOptionShouldOnlySetData()
+    {
+        Brain\Monkey\Functions\expect('get_option')
+            ->twice()
+            ->andReturn(false);
+
+        Brain\Monkey\Functions\expect('update_option')
+            ->never();
+
+        $config = new Config();
+        $config->setAccountId('acc_123');
+
+        $this->assertEquals('acc_123', $config->getData('account_id'));
+    }
+
+    public function testSetPaymentProfileIdShouldSetDataCorrectly()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setPaymentProfileId('profile_123');
+
+        $this->assertEquals('profile_123', $config->getData('payment_profile_id'));
+    }
+
+    public function testSetPoiTypeShouldSetDataCorrectly()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setPoiType('type_123');
+
+        $this->assertEquals('type_123', $config->getData('poi_type'));
+    }
+
+    public function testGetPaymentProfileIdShouldReturnStoredValue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('payment_profile_id', 'profile_456');
+
+        $result = $config->getPaymentProfileId();
+
+        $this->assertEquals('profile_456', $result);
+    }
+
+    public function testGetPoiTypeShouldReturnStoredValue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('poi_type', 'type_456');
+
+        $result = $config->getPoiType();
+
+        $this->assertEquals('type_456', $result);
+    }
+
+    // ==========================================
+    // 13. TESTES DE ONESTONE
+    // ==========================================
+
+    public function testIsOneStoneEnabledWithPaymentProfileIdShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('payment_profile_id', 'profile_123');
+
+        $result = $config->isOneStoneEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsOneStoneEnabledWithoutPaymentProfileIdShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+
+        $result = $config->isOneStoneEnabled();
+
+        $this->assertFalse($result);
+    }
+
+    // ==========================================
+    // 14. TESTES DE INSTALLMENTS
+    // ==========================================
+
+    public function testGetIsInstallmentsDefaultConfigWithLegacyTypeShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('cc_installment_type', CardInstallments::INSTALLMENTS_LEGACY);
+
+        $result = $config->getIsInstallmentsDefaultConfig();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetIsInstallmentsDefaultConfigWithAllFlagsTypeShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('cc_installment_type', CardInstallments::INSTALLMENTS_FOR_ALL_FLAGS);
+
+        $result = $config->getIsInstallmentsDefaultConfig();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetIsInstallmentsDefaultConfigWithOtherTypeShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('cc_installment_type', CardInstallments::INSTALLMENTS_BY_FLAG);
+
+        $result = $config->getIsInstallmentsDefaultConfig();
+
+        $this->assertFalse($result);
+    }
+
+    public function testGetInstallmentTypeShouldReturnStoredValue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('cc_installment_type', CardInstallments::INSTALLMENTS_BY_FLAG);
+
+        $result = $config->getInstallmentType();
+
+        $this->assertEquals(CardInstallments::INSTALLMENTS_BY_FLAG, $result);
+    }
+
+    // ==========================================
+    // 15. TESTES DE FEATURE FLAGS AUXILIARES
+    // ==========================================
+
+    public function testGetMulticustomersShouldCheckMulticustomersFlag()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('multicustomers', Config::ENABLED);
+
+        $result = $config->getMulticustomers();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetModifyAddressShouldCheckModifyAddressFlag()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('modify_address', Config::ENABLED);
+
+        $result = $config->getModifyAddress();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetAllowNoAddressShouldCheckAllowNoAddressFlag()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('allow_no_address', Config::ENABLED);
+
+        $result = $config->getAllowNoAddress();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetCcAllowSaveShouldCheckCcAllowSaveFlag()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('cc_allow_save', Config::ENABLED);
+
+        $result = $config->getCcAllowSave();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetVoucherCardWalletShouldCheckVoucherCardWalletFlag()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('voucher_card_wallet', Config::ENABLED);
+
+        $result = $config->getVoucherCardWallet();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetEnableLogsShouldCheckEnableLogsFlag()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('enable_logs', Config::ENABLED);
+
+        $result = $config->getEnableLogs();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetIsGatewayIntegrationTypeShouldCheckFlag()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('is_gateway_integration_type', Config::ENABLED);
+
+        $result = $config->getIsGatewayIntegrationType();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetAntifraudEnabledShouldCheckAntifraudEnabledFlag()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('antifraud_enabled', Config::ENABLED);
+
+        $result = $config->getAntifraudEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    // ==========================================
+    // 16. TESTES DE VOUCHER PSP
+    // ==========================================
+
+    public function testGetIsVoucherPSPWithVoucherTrueShouldReturnTrue()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('is_payment_psp', ['voucher' => true]);
+
+        $result = $config->getIsVoucherPSP();
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetIsVoucherPSPWithVoucherFalseShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('is_payment_psp', ['voucher' => false]);
+
+        $result = $config->getIsVoucherPSP();
+
+        $this->assertFalse($result);
+    }
+
+    public function testGetIsVoucherPSPWithoutVoucherKeyShouldReturnFalse()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+        $config->setData('is_payment_psp', ['credit_card' => true]);
+
+        $result = $config->getIsVoucherPSP();
+
+        $this->assertFalse($result);
+    }
+
+    // ==========================================
+    // 17. TESTES DE LOGGER
+    // ==========================================
+
+    public function testLogShouldReturnWCLoggerInstance()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $config = new Config();
+
+        $result = $config->log();
+
+        $this->assertInstanceOf(WC_Logger::class, $result);
+    }
+
+    // ==========================================
+    // 18. TESTES DE OPTION KEY
+    // ==========================================
+
+    public function testGetOptionKeyShouldReturnPrefixedSettingsKey()
+    {
+        Brain\Monkey\Functions\stubs([
+            'get_option' => false,
+        ]);
+
+        $coreMock = Mockery::mock('alias:' . Core::class);
+        $coreMock->shouldReceive('tag_name')
+            ->with('settings')
+            ->andReturn('pagarme_settings');
+
+        $config = new Config();
+
+        $result = $config->getOptionKey();
+
+        $this->assertEquals('pagarme_settings', $result);
+    }
+}

--- a/tests/Model/ConfigTest.php
+++ b/tests/Model/ConfigTest.php
@@ -384,7 +384,7 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('payment_profile_id', 'pp_123');
+        $config->setData(Config::PAYMENT_PROFILE_ID, 'pp_123');
 
         $result = $config->isPagarmeDashConfigAccessible();
 
@@ -402,7 +402,7 @@ class ConfigTest extends TestCase
 
         $config = new Config();
         $config->setData('merchant_id', 'merch_123');
-        $config->setData('account_id', 'acc_123');
+        $config->setData(Config::ACCOUNT_ID, 'acc_123');
 
         $result = $config->isPagarmeDashConfigAccessible();
 
@@ -436,7 +436,7 @@ class ConfigTest extends TestCase
 
         $config = new Config();
         $config->setData('merchant_id', 'merch_123');
-        $config->setData('account_id', 'acc_456');
+        $config->setData(Config::ACCOUNT_ID, 'acc_456');
 
         $result = $config->getPagarmeDashUrl();
 
@@ -1028,7 +1028,7 @@ class ConfigTest extends TestCase
     public function testSetAccountIdShouldSetDataAndUpdateGooglepay()
     {
         Brain\Monkey\Functions\stubs([
-            'get_option' => ['account_id' => 'acc_old'],
+            'get_option' => [Config::ACCOUNT_ID => 'acc_old'],
         ]);
 
         $coreMock = Mockery::mock('alias:' . Core::class);
@@ -1037,13 +1037,13 @@ class ConfigTest extends TestCase
         Brain\Monkey\Functions\expect('update_option')
             ->once()
             ->with('woocommerce_woo-pagarme-payments-googlepay_settings', Mockery::on(function ($arg) {
-                return is_array($arg) && $arg['account_id'] === 'acc_123';
+                return is_array($arg) && $arg[Config::ACCOUNT_ID] === 'acc_123';
             }));
 
         $config = new Config();
         $config->setAccountId('acc_123');
 
-        $this->assertEquals('acc_123', $config->getData('account_id'));
+        $this->assertEquals('acc_123', $config->getData(Config::ACCOUNT_ID));
     }
 
     public function testSetAccountIdWithoutGooglepayOptionShouldOnlySetData()
@@ -1061,7 +1061,7 @@ class ConfigTest extends TestCase
         $config = new Config();
         $config->setAccountId('acc_123');
 
-        $this->assertEquals('acc_123', $config->getData('account_id'));
+        $this->assertEquals('acc_123', $config->getData(Config::ACCOUNT_ID));
     }
 
     public function testSetPaymentProfileIdShouldSetDataCorrectly()
@@ -1076,7 +1076,7 @@ class ConfigTest extends TestCase
         $config = new Config();
         $config->setPaymentProfileId('pp_123');
 
-        $this->assertEquals('pp_123', $config->getData('payment_profile_id'));
+        $this->assertEquals('pp_123', $config->getData(Config::PAYMENT_PROFILE_ID));
     }
 
     public function testSetPoiTypeShouldSetDataCorrectly()
@@ -1091,7 +1091,7 @@ class ConfigTest extends TestCase
         $config = new Config();
         $config->setPoiType('ecommerce');
 
-        $this->assertEquals('ecommerce', $config->getData('poi_type'));
+        $this->assertEquals('ecommerce', $config->getData(Config::POI_TYPE));
     }
 
     public function testGetPaymentProfileIdShouldReturnStoredValue()
@@ -1104,7 +1104,7 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('payment_profile_id', 'pp_456');
+        $config->setData(Config::PAYMENT_PROFILE_ID, 'pp_456');
 
         $result = $config->getPaymentProfileId();
 
@@ -1121,7 +1121,7 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('poi_type', 'ecommerce');
+        $config->setData(Config::POI_TYPE, 'ecommerce');
 
         $result = $config->getPoiType();
 
@@ -1138,7 +1138,7 @@ class ConfigTest extends TestCase
         $coreMock->shouldReceive('tag_name')->andReturn('pagarme_settings');
 
         $config = new Config();
-        $config->setData('payment_profile_id', 'pp_123');
+        $config->setData(Config::PAYMENT_PROFILE_ID, 'pp_123');
 
         $result = $config->isOneStoneEnabled();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,15 +4,12 @@
  * PHPUnit bootstrap file for Pagarme Payments for WooCommerce tests
  */
 
-// Load Composer autoloader
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-// Define WordPress constants if not already defined
 if (!defined('ABSPATH')) {
     define('ABSPATH', '/tmp/wordpress/');
 }
 
-// Define plugin constants needed for tests
 if (!defined('WCMP_SLUG')) {
     define('WCMP_SLUG', 'woo-pagarme-payments');
 }
@@ -53,7 +50,6 @@ if (!defined('WCMP_JS_HANDLER_BASE_NAME')) {
     define('WCMP_JS_HANDLER_BASE_NAME', 'pagarme_scripts_');
 }
 
-// Mock WooCommerce classes that may be needed in tests
 if (!class_exists('WC_Logger')) {
     /**
      * Mock WC_Logger class for testing
@@ -62,13 +58,11 @@ if (!class_exists('WC_Logger')) {
     {
         public function add($handle, $message, $level = 'info')
         {
-            // Mock implementation
             return true;
         }
 
         public function log($level, $message, $context = [])
         {
-            // Mock implementation
             return true;
         }
 
@@ -113,5 +107,3 @@ if (!class_exists('WC_Logger')) {
         }
     }
 }
-
-// Note: Brain Monkey setup is handled in each test class's setUp() method

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,5 +53,65 @@ if (!defined('WCMP_JS_HANDLER_BASE_NAME')) {
     define('WCMP_JS_HANDLER_BASE_NAME', 'pagarme_scripts_');
 }
 
-// Initialize Brain Monkey for WordPress function mocking
-\Brain\Monkey\setUp();
+// Mock WooCommerce classes that may be needed in tests
+if (!class_exists('WC_Logger')) {
+    /**
+     * Mock WC_Logger class for testing
+     */
+    class WC_Logger
+    {
+        public function add($handle, $message, $level = 'info')
+        {
+            // Mock implementation
+            return true;
+        }
+
+        public function log($level, $message, $context = [])
+        {
+            // Mock implementation
+            return true;
+        }
+
+        public function emergency($message, $context = [])
+        {
+            return $this->log('emergency', $message, $context);
+        }
+
+        public function alert($message, $context = [])
+        {
+            return $this->log('alert', $message, $context);
+        }
+
+        public function critical($message, $context = [])
+        {
+            return $this->log('critical', $message, $context);
+        }
+
+        public function error($message, $context = [])
+        {
+            return $this->log('error', $message, $context);
+        }
+
+        public function warning($message, $context = [])
+        {
+            return $this->log('warning', $message, $context);
+        }
+
+        public function notice($message, $context = [])
+        {
+            return $this->log('notice', $message, $context);
+        }
+
+        public function info($message, $context = [])
+        {
+            return $this->log('info', $message, $context);
+        }
+
+        public function debug($message, $context = [])
+        {
+            return $this->log('debug', $message, $context);
+        }
+    }
+}
+
+// Note: Brain Monkey setup is handled in each test class's setUp() method

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * PHPUnit bootstrap file for Pagarme Payments for WooCommerce tests
+ */
+
+// Load Composer autoloader
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+// Define WordPress constants if not already defined
+if (!defined('ABSPATH')) {
+    define('ABSPATH', '/tmp/wordpress/');
+}
+
+// Define plugin constants needed for tests
+if (!defined('WCMP_SLUG')) {
+    define('WCMP_SLUG', 'woo-pagarme-payments');
+}
+
+if (!defined('WCMP_PREFIX')) {
+    define('WCMP_PREFIX', 'pagarme');
+}
+
+if (!defined('WCMP_VERSION')) {
+    define('WCMP_VERSION', '3.6.1');
+}
+
+if (!defined('WCMP_ROOT_PATH')) {
+    define('WCMP_ROOT_PATH', dirname(__DIR__) . '/');
+}
+
+if (!defined('WCMP_ROOT_SRC')) {
+    define('WCMP_ROOT_SRC', WCMP_ROOT_PATH . 'src/');
+}
+
+if (!defined('WCMP_ROOT_FILE')) {
+    define('WCMP_ROOT_FILE', WCMP_ROOT_PATH . WCMP_SLUG . '.php');
+}
+
+if (!defined('WCMP_OPTION_ACTIVATE')) {
+    define('WCMP_OPTION_ACTIVATE', 'wcmp_official_activate');
+}
+
+if (!defined('WCMP__FILE__')) {
+    define('WCMP__FILE__', dirname(__DIR__) . '/constants.php');
+}
+
+if (!defined('WCMP_PLUGIN_BASE')) {
+    define('WCMP_PLUGIN_BASE', 'woo-pagarme-payments/woo-pagarme-payments.php');
+}
+
+if (!defined('WCMP_JS_HANDLER_BASE_NAME')) {
+    define('WCMP_JS_HANDLER_BASE_NAME', 'pagarme_scripts_');
+}
+
+// Initialize Brain Monkey for WordPress function mocking
+\Brain\Monkey\setUp();


### PR DESCRIPTION
![Monty Python Black Knight Arm Off](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExejhvM3IzaHB2YWd5MDljam90YzhucTR0ZmpnNG5jeGNzZ2JxNmFuZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/6Y49Ck6FxF4nS/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [x] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Foi atualizado a classe `Config` para expor `PaymentProfileId` e `PoiType`.

### Cenários testados
A classe `Config` não possuia testes unitários. Criei testes para todos os cenários, não apenas os métodos que adicionei.

Também foi adicionado um bootstrap para trabalhar com mock, e com isso foi necessário alterar dois outros testes: `WoocommerceCoreSetupTest.php` e `WoocommercePlatformOrderDecoratorTest.php` para o funcionamento correto dos mesmos.

<img width="805" height="222" alt="image" src="https://github.com/user-attachments/assets/3a0ba7a0-8220-437a-a015-0865062e7f26" />