### PR TITLE
chore: remove one stone urls

### DIFF
--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -286,8 +286,7 @@ class Config extends DataObject
             return null;
         }
         return esc_url(sprintf(
-            'https://conta.stone.com.br/%s/',
-            $this->getPaymentProfileId()
+            'https://conta.stone.com.br/'
         ));
     }
 

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -159,7 +159,7 @@ class Config extends DataObject
     private function getHubBaseUrl()
     {
         return sprintf(
-            'https://hub.stone.com.br/redirect-onestone/#/?q=/apps/%s/authorize',
+            'https://hub.pagar.me/apps/%s/authorize',
             $this->getHubAppId()
         );
     }
@@ -182,7 +182,7 @@ class Config extends DataObject
     private function getHubViewIntegrationUrl()
     {
         return sprintf(
-            'https://hub.stone.com.br/redirect-onestone/#/?q=/apps/%s/edit/%s',
+            'https://hub.pagar.me/apps/%s/edit/%s',
             $this->getHubAppId(),
             $this->getHubInstallId()
         );
@@ -286,7 +286,8 @@ class Config extends DataObject
             return null;
         }
         return esc_url(sprintf(
-            'https://conta.stone.com.br'
+            'https://conta.stone.com.br/%s/',
+            $this->getPaymentProfileId()
         ));
     }
 

--- a/src/Model/Gateway.php
+++ b/src/Model/Gateway.php
@@ -120,7 +120,7 @@ class Gateway
     private function get_hub_integrate_url()
     {
         $baseUrl = sprintf(
-            'https://hub.stone.com.br/redirect-onestone/#/?q=/apps/%s/authorize',
+            'https://hub.pagar.me/apps/%s/authorize',
             $this->get_hub_app_id()
         );
 
@@ -136,7 +136,7 @@ class Gateway
     private function get_hub_view_integration_url($hub_install_id)
     {
         return sprintf(
-            'https://hub.stone.com.br/redirect-onestone/#/?q=/apps/%s/edit/%s',
+            'https://hub.pagar.me/apps/%s/edit/%s',
             $this->get_hub_app_id(),
             $hub_install_id
         );

--- a/tests/Model/ConfigTest.php
+++ b/tests/Model/ConfigTest.php
@@ -349,7 +349,7 @@ class ConfigTest extends TestCase
 
         $result = $config->getHubUrl();
 
-        $this->assertStringContainsString('https://hub.stone.com.br/redirect-onestone/#/?q=/apps/test_app_id/authorize', $result);
+        $this->assertStringContainsString('https://hub.pagar.me/apps/test_app_id/authorize', $result);
         $this->assertStringContainsString('install_token=install_token_123', $result);
     }
 
@@ -371,7 +371,7 @@ class ConfigTest extends TestCase
 
         $result = $config->getHubUrl();
 
-        $this->assertEquals('https://hub.stone.com.br/redirect-onestone/#/?q=/apps/test_app_id/edit/install_123', $result);
+        $this->assertEquals('https://hub.pagar.me/apps/test_app_id/edit/install_123', $result);
     }
 
     public function testIsDashConfigAccessibleWithPaymentProfileIdShouldReturnFalse()


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [x] Refatoração
- [ ] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Reversão das URLs do Hub de Integração no plugin do WooCommerce, substituindo os endpoints de redirecionamento do OneStone (`hub.stone.com.br`) de volta para as URLs originais da Pagar.me (`hub.pagar.me`).

**Resumo das alterações:**
* Restauração das URLs base de autorização e edição da integração nos arquivos `src/Model/Config.php` e `src/Model/Gateway.php`.
* Ajuste na formatação da URL da conta Stone em `Config.php`.
* Atualização dos testes unitários em `tests/Model/ConfigTest.php` para validar os endpoints corretos da Pagar.me (`https://hub.pagar.me/...`).

### Cenários testados
- [x] Execução da suíte de testes unitários (`PHPUnit`) para validação das URLs do Hub em `ConfigTest.php`.
- [x] Validação da geração do link de autorização/integração do Hub no painel do WooCommerce.
- [x] Validação do link de edição da integração já instalada (`get_hub_view_integration_url`).

[HPIP-431](https://allstone.atlassian.net/browse/HPIP-431)

[HPIP-431]: https://allstone.atlassian.net/browse/HPIP-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ